### PR TITLE
Update .gitignore since the Roslyn cache folder was renamed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ bld/
 [Oo]bj/
 
 # Roslyn cache directories
-*.ide/
+*.vs/
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
Starting with Visual Studio 2015 CTP 5, the IntelliSense cache folder was renamed from **{SolutionName}.sln.ide** to just **.vs**. This change assumes people won't still be using the old CTPs of Visual Studio 2015, and updates .gitignore to ignore the new cache name.