### PR TITLE
Make sure HTML rules are used when saving the final HTML output

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBConceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBConceptual.config
@@ -155,7 +155,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -203,7 +203,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -254,7 +254,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="false" add-xhtml-namespace="true" />
+								omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -297,7 +297,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBReference.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/SHFBReference.config
@@ -282,7 +282,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -325,7 +325,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -371,7 +371,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" />
+								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -409,7 +409,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/conceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/conceptual.config
@@ -175,7 +175,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base=".\Output\html" path="concat($key,'.htm')" link="../html" indent="true"
-						omit-xml-declaration="true" />
+						omit-xml-declaration="true" outputMethod="html" />
 				</component>
 
 				<!-- Record file creation events -->

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle-mshc.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle-mshc.config
@@ -204,7 +204,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="true"
-						omit-xml-declaration="false" add-xhtml-namespace="true" />
+						omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle.config
+++ b/SHFB/Source/PresentationStyles/VS2005/Configuration/sandcastle.config
@@ -197,7 +197,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="true"
-						omit-xml-declaration="true" />
+						omit-xml-declaration="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBConceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBConceptual.config
@@ -176,7 +176,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -232,7 +232,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -291,7 +291,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="false" add-xhtml-namespace="true" />
+								omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -341,7 +341,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBReference.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/SHFBReference.config
@@ -294,7 +294,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -345,7 +345,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -399,7 +399,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" />
+								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -444,7 +444,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/conceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/conceptual.config
@@ -162,7 +162,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base=".\Output\html" path="concat($key,'.htm')" indent="false" omit-xml-declaration="true"
-						add-xhtml-namespace="true" />
+						add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle-mshc.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle-mshc.config
@@ -212,7 +212,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="false"
-						omit-xml-declaration="false" add-xhtml-namespace="true" />
+						omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle.config
+++ b/SHFB/Source/PresentationStyles/VS2010/Configuration/sandcastle.config
@@ -204,7 +204,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="false"
-						omit-xml-declaration="true" add-xhtml-namespace="true" />
+						omit-xml-declaration="true" add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2013/Configuration/SHFBConceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2013/Configuration/SHFBConceptual.config
@@ -176,7 +176,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -232,7 +232,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -291,7 +291,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="false" add-xhtml-namespace="true" />
+								omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -344,7 +344,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat($key,'.htm')" indent="{@IndentHtml}"
-								omit-xml-declaration="true" add-xhtml-namespace="false" />
+								omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2013/Configuration/SHFBReference.config
+++ b/SHFB/Source/PresentationStyles/VS2013/Configuration/SHFBReference.config
@@ -298,7 +298,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\HtmlHelp1\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -349,7 +349,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelp2\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -403,7 +403,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\MSHelpViewer\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" />
+								indent="{@IndentHtml}" omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 						</component>
 					</helpOutput>
 
@@ -451,7 +451,7 @@
 						<!-- Save the result -->
 						<component id="Save Component">
 							<save base="Output\Website\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')"
-								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" />
+								indent="{@IndentHtml}" omit-xml-declaration="true" add-xhtml-namespace="false" outputMethod="html" />
 						</component>
 					</helpOutput>
 				</component>

--- a/SHFB/Source/PresentationStyles/VS2013/Configuration/conceptual.config
+++ b/SHFB/Source/PresentationStyles/VS2013/Configuration/conceptual.config
@@ -162,7 +162,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base=".\Output\html" path="concat($key,'.htm')" indent="false" omit-xml-declaration="true"
-						add-xhtml-namespace="true" />
+						add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2013/Configuration/sandcastle-mshc.config
+++ b/SHFB/Source/PresentationStyles/VS2013/Configuration/sandcastle-mshc.config
@@ -212,7 +212,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="false"
-						omit-xml-declaration="false" add-xhtml-namespace="true" />
+						omit-xml-declaration="false" add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>

--- a/SHFB/Source/PresentationStyles/VS2013/Configuration/sandcastle.config
+++ b/SHFB/Source/PresentationStyles/VS2013/Configuration/sandcastle.config
@@ -204,7 +204,7 @@
 				<!-- Save the result -->
 				<component id="Save Component">
 					<save base =".\Output\html" path="concat(/html/head/meta[@name='file']/@content,'.htm')" indent="false"
-						omit-xml-declaration="true" add-xhtml-namespace="true" />
+						omit-xml-declaration="true" add-xhtml-namespace="true" outputMethod="html" />
 				</component>
 
 			</components>


### PR DESCRIPTION
This commit sets the `outputMethod="html"` attribute during the final save operation for HTML files. This change ensures that even if special HTML elements (like `p` or `div`) are empty, the resulting files contain the expected results. The styles may still contain workarounds such as the insertion of comments to make sure these tags aren't written as self-closing elements; while now unnecessary these workarounds are harmless and no effort has been made to find and remove them.