### PR TITLE
Improved support for HTML 5 browsers

### DIFF
--- a/SHFB/Source/BuildAssembler/BuildComponents/SaveComponent.cs
+++ b/SHFB/Source/BuildAssembler/BuildComponents/SaveComponent.cs
@@ -174,6 +174,19 @@ namespace Microsoft.Ddue.Tools
                 document.LoadXml(document.OuterXml);
             }
 
+            if (settings.OutputMethod == XmlOutputMethod.Html)
+            {
+                XmlDocumentType documentType = document.CreateDocumentType("html", null, null, null);
+                if (document.DocumentType != null)
+                {
+                    document.ReplaceChild(documentType, document.DocumentType);
+                }
+                else
+                {
+                    document.InsertBefore(documentType, document.FirstChild);
+                }
+            }
+
             // Save the document.
 
             // selectExpression determines which nodes get saved. If there is no selectExpression we simply

--- a/SHFB/Source/PresentationStyles/VS2013/Transforms/main_conceptual.xsl
+++ b/SHFB/Source/PresentationStyles/VS2013/Transforms/main_conceptual.xsl
@@ -51,6 +51,7 @@
 	<xsl:template match="/document" name="t_document">
 		<html>
 			<head>
+				<meta charset="utf-8"/>
 				<link rel="shortcut icon">
 					<includeAttribute name="href" item="iconPath">
 						<parameter>
@@ -81,7 +82,6 @@
 					<xsl:text> </xsl:text>
 				</script>
 
-				<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 				<xsl:call-template name="t_insertNoIndexNoFollow"/>
 				<title>
 					<xsl:call-template name="t_topicTitlePlain"/>

--- a/SHFB/Source/PresentationStyles/VS2013/Transforms/utilities_reference.xsl
+++ b/SHFB/Source/PresentationStyles/VS2013/Transforms/utilities_reference.xsl
@@ -91,6 +91,7 @@
 	<xsl:template match="/">
 		<html>
 			<head>
+				<meta charset="utf-8"/>
 				<link rel="shortcut icon">
 					<includeAttribute name="href" item="iconPath">
 						<parameter>
@@ -121,7 +122,6 @@
 					<xsl:text> </xsl:text>
 				</script>
 
-				<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 				<xsl:call-template name="t_insertNoIndexNoFollow"/>
 				<title>
 					<xsl:call-template name="t_topicTitlePlain">


### PR DESCRIPTION
When adjusting the CSS to more closely match certain aspects of the MSDN site, I found that some behavior did not behave as expected. Adding a `<!DOCTYPE html>` document type declaration corrected this.

* Emit `<!DOCTYPE html>` at the top when saving as HTML
* Use a `<meta>` element that just gives the charset, and make sure it appears first
