### PR TITLE
Implement support for RipOldApis on individual versions

### DIFF
--- a/SHFB/Source/SandcastleBuilderPlugIns/VersionBuilderPlugIn.cs
+++ b/SHFB/Source/SandcastleBuilderPlugIns/VersionBuilderPlugIn.cs
@@ -140,6 +140,7 @@ namespace SandcastleBuilder.PlugIns
             {
                 currentVersion.FrameworkLabel = node.GetAttribute("label", String.Empty).Trim();
                 currentVersion.Version = node.GetAttribute("version", String.Empty).Trim();
+                currentVersion.RipOldApis = false;
 
                 ripOld = node.GetAttribute("ripOldApis", String.Empty);
 
@@ -422,9 +423,9 @@ namespace SandcastleBuilder.PlugIns
                 foreach(VersionSettings vs in allVersions)
                     if(vs.FrameworkLabel == label)
                     {
-                        config.AppendFormat("    <version name=\"SHFB_VBPI_{0}\" file=\"{1:X}.ver\" />\r\n",
+                        config.AppendFormat("    <version name=\"SHFB_VBPI_{0}\" file=\"{1:X}.ver\" ripOldApis=\"{2}\" />\r\n",
                             (vs.FrameworkLabel + " " + vs.Version).GetHashCode().ToString("X",
-                            CultureInfo.InvariantCulture), vs.GetHashCode());
+                            CultureInfo.InvariantCulture), vs.GetHashCode(), vs.RipOldApis);
 
                         File.Copy(vs.ReflectionFilename, Path.Combine(builder.WorkingFolder,
                             String.Format(CultureInfo.InvariantCulture, "{0:X}.ver", vs.GetHashCode())), true);

--- a/SHFB/Source/SandcastleBuilderPlugIns/VersionSettings.cs
+++ b/SHFB/Source/SandcastleBuilderPlugIns/VersionSettings.cs
@@ -46,6 +46,7 @@ namespace SandcastleBuilder.PlugIns
 
         private string frameworkLabel, version, reflectionFilename;
         private FilePath helpFileProject;
+        private bool ripOldApis;
         #endregion
 
         #region Properties
@@ -97,6 +98,17 @@ namespace SandcastleBuilder.PlugIns
                 if(String.IsNullOrEmpty(version))
                     version = "1.0";
             }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to remove old APIs from
+        /// the final output.
+        /// </summary>
+        [Category("Framework"), Description("Remove old APIs no longer in latest versions")]
+        public bool RipOldApis
+        {
+            get { return ripOldApis; }
+            set { ripOldApis = value; }
         }
 
         /// <summary>
@@ -199,8 +211,8 @@ namespace SandcastleBuilder.PlugIns
         /// <returns>A <see cref="VersionSettings"/> object containing the
         /// settings from the XPath navigator.</returns>
         /// <remarks>It should contain an element called <c>version</c>
-        /// with three attributes (<c>label</c>, <c>version</c> and
-        /// <c>helpFileProject</c>).</remarks>
+        /// with four attributes (<c>label</c>, <c>version</c>,
+        /// <c>ripOldApis</c>, and <c>helpFileProject</c>).</remarks>
         public static VersionSettings FromXPathNavigator(
           IBasePathProvider pathProvider, XPathNavigator navigator)
         {
@@ -212,6 +224,10 @@ namespace SandcastleBuilder.PlugIns
                     String.Empty).Trim();
                 vs.Version = navigator.GetAttribute("version",
                     String.Empty).Trim();
+
+                string ripOldApis = navigator.GetAttribute("ripOldApis", String.Empty);
+                vs.RipOldApis = !String.IsNullOrEmpty(ripOldApis) && Convert.ToBoolean(ripOldApis);
+
                 vs.HelpFileProject = new FilePath(navigator.GetAttribute(
                     "helpFileProject", String.Empty).Trim(), pathProvider);
             }
@@ -248,6 +264,10 @@ namespace SandcastleBuilder.PlugIns
 
             attr = config.CreateAttribute("version");
             attr.Value = version;
+            node.Attributes.Append(attr);
+
+            attr = config.CreateAttribute("ripOldApis");
+            attr.Value = ripOldApis.ToString();
             node.Attributes.Append(attr);
 
             attr = config.CreateAttribute("helpFileProject");

--- a/SHFB/Source/VersionBuilder/VersionBuilderCore.cs
+++ b/SHFB/Source/VersionBuilder/VersionBuilderCore.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using System.Xml.XPath;
 
@@ -112,19 +113,24 @@ namespace Microsoft.Ddue.Tools
                 if(String.IsNullOrEmpty(attribute))
                     ConsoleApplication.WriteMessage(LogLevel.Error, "Every version element must have a file attribute.");
 
+                string ripOldString = navigator2.GetAttribute("ripOldApis", String.Empty);
+                bool ripOld = ripOldString == "1" || String.Equals("true", ripOldString, StringComparison.OrdinalIgnoreCase);
+
                 name = Environment.ExpandEnvironmentVariables(name);
-                VersionInfo item = new VersionInfo(attribute, group, name);
+                VersionInfo item = new VersionInfo(attribute, group, name, ripOld);
                 allVersions.Add(item);
             }
 
             string str5 = String.Empty;
 
             foreach(VersionInfo info2 in allVersions)
-                if(info2.Group != str5)
+                if(!info2.RipOldApis && (!rip || info2.Group != str5))
                 {
                     latestVersions.Add(info2.Name);
                     str5 = info2.Group;
                 }
+
+            bool ripAny = rip || allVersions.Any(i => i.RipOldApis);
 
             if(Cancel)
             {
@@ -289,7 +295,7 @@ namespace Microsoft.Ddue.Tools
                 }
             }
 
-            if(rip)
+            if(ripAny)
                 RemoveOldApis(versionIndex, latestVersions);
 
             ConsoleApplication.WriteMessage(LogLevel.Info, String.Format(CultureInfo.CurrentCulture,
@@ -418,7 +424,7 @@ namespace Microsoft.Ddue.Tools
                                                 {
                                                     foreach(string str13 in dictionary5.Keys)
                                                     {
-                                                        if(dictionary6.ContainsKey(str13) || (rip && !IsLatestElement(dictionary5[str13].Versions.Values, latestVersions)))
+                                                        if(dictionary6.ContainsKey(str13) || (ripAny && !IsLatestElement(dictionary5[str13].Versions.Values, latestVersions)))
                                                         {
                                                             continue;
                                                         }

--- a/SHFB/Source/VersionBuilder/VersionInfo.cs
+++ b/SHFB/Source/VersionBuilder/VersionInfo.cs
@@ -6,13 +6,15 @@
         public string File { get; private set; }
         public string Group { get; private set; }
         public string Name { get; private set; }
+        public bool RipOldApis { get; private set; }
 
         // Methods
-        public VersionInfo(string name, string group, string file)
+        public VersionInfo(string name, string group, string file, bool ripOldApis)
         {
             this.Name = name;
             this.Group = group;
             this.File = file;
+            this.RipOldApis = ripOldApis;
         }
     }
 }


### PR DESCRIPTION
This is not a perfect fix for issue #7, but it's a minimal implementation of the essential functionality we are using. This functionality allows us to include the comprehensive **Version Information** section you see at the bottom of [this page](http://openstacknetsdk.org/docs/html/T_net_openstack_Core_Providers_IBlockStorageProvider.htm), without worrying about the table of contents becoming cluttered with behavior that has since been removed.

I don't expect this to be merge in its exact current form, but I'd really like to find a nice way to resolve the concerns we have our use of the Version Builder plugin so our documentation builds can move back to using this reference distribution of SHFB. :smile: 
