### PR TITLE
Only collapse topmost sections

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/Transforms/utilities_dduexml.xsl
+++ b/SHFB/Source/PresentationStyles/VS2013/Transforms/utilities_dduexml.xsl
@@ -174,7 +174,7 @@
 				<!-- Don't render the 'Change History' section here; it's handled in the t_writeChangeHistorySection template. -->
 				<xsl:when test="ddue:title = 'Change History'"/>
 
-				<xsl:when test="($total = 0) or ($total = 1)">
+				<xsl:when test="$total = 0">
 					<xsl:call-template name="t_putSection">
 						<xsl:with-param name="p_title">
 							<xsl:apply-templates select="ddue:title" mode="section"/>


### PR DESCRIPTION
This commit changes 2nd-level headings in the HTML output of MAML documents to
be non-collapsible subsections instead of main sections.

I found it difficult to write certain content using the current style implementation. The problem (for me) is highlighted by content like [this Attributes section](http://ewsoftware.github.io/XMLCommentsGuide/html/1abd1992-e3d0-45b4-b43d-91fcfc5e5574.htm#Attributes). After this change, the children of the Attributes section are no longer collapsible top-level elements, so they [appear like this](http://tunnelvisionlabs.github.io/SHFB/docs-master/XMLCommentsGuide/html/1abd1992-e3d0-45b4-b43d-91fcfc5e5574.htm#Attributes).