### PR TITLE
Spacing tweaks for block content

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/styles/branding.css
+++ b/SHFB/Source/PresentationStyles/VS2013/styles/branding.css
@@ -248,7 +248,7 @@ div.caption {
 	cursor: pointer;
 }
 .collapsibleSection {
-	margin-top: 5px;
+	padding: 0 0 0 20px;
 }
 
 /* Syntax and code snippet styles */


### PR DESCRIPTION
* Indent content of collapsible sections. This impact can be seen by comparing the alignment of the left edge of the main content on [this page (not indented)](http://ewsoftware.github.io/XMLCommentsGuide/html/81bf7ad3-45dc-452f-90d5-87ce2494a182.htm) with the content on [this page (indented)](http://tunnelvisionlabs.github.io/SHFB/docs-master/XMLCommentsGuide/html/81bf7ad3-45dc-452f-90d5-87ce2494a182.htm). Keep in mind this is closely related to #48 - if this change is applied without #48, some MAML content will receive two levels of indentation.
* Remove space between paragraphs in tables. This change significantly improves the ease of reading multi-line [conditions in exception tables](http://openstacknetsdk.org/docs-v2/html/M_OpenStack_Services_IHttpService_PrepareRequestAsyncFunc__1.htm).
* Slightly "tighten" the vertical spacing overall