### PR TITLE
Show language-specific keywords in prose as bold, not blue

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/styles/branding.css
+++ b/SHFB/Source/PresentationStyles/VS2013/styles/branding.css
@@ -430,6 +430,10 @@ div.caption {
 	font-weight: normal;
 	-ms-word-wrap: normal;
 }
+.codeSnippetContainerCode .keyword {
+	color: #0000ff;
+	font-weight: normal;
+}
 
 /* Keyword and phrase styles */
 span.code, span.command {
@@ -463,7 +467,7 @@ span.typeparameter {
 span.identifier {
 }
 span.keyword {
-	color: #0000ff;
+	font-weight: bold;
 }
 span.parameter {
 	font-style: italic;


### PR DESCRIPTION
This style for language-specific keywords matches the display on MSDN. I found the blue text disruptive and/or difficult to distinguish from hyperlinks on pages like [this](http://rackerlabs.github.io/dotnet-threading/docs-latest/html/0a33afc9-793d-448a-950f-f03a2ca156d2.htm) (note this example already uses bold, not blue, for the keywords).