### PR TITLE
Simplify CSS styling for definition lists

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/styles/branding.css
+++ b/SHFB/Source/PresentationStyles/VS2013/styles/branding.css
@@ -139,17 +139,8 @@ ul ul {
 ul ul ul {
 	list-style-type: square;
 }
-dl {
-	margin-top: 0px;
-	margin-bottom: 10px;
-}
 dt {
-	font-weight: bold;
-	margin-top: 5px;
-}
-dd {
-	margin-left: 20px;
-	margin-bottom: 5px;
+	font-weight: 600;
 }
 pre {
 	font-family: Consolas, Courier, monospace;


### PR DESCRIPTION
The MSDN site does not include CSS styling for definition lists. I removed it and found the result to be quite acceptable IMO. An example definition list without the styling [can be seen here](http://rackerlabs.github.io/dotnet-threading/docs-latest/html/e02b9881-f06b-4420-aace-71b176d635db.htm).