### PR TITLE
AddNamespaceGroups plugin: [fix] include the root namespace in the count...

### DIFF
--- a/SHFB/Source/AddNamespaceGroups/AddNamespaceGroupsCore.cs
+++ b/SHFB/Source/AddNamespaceGroups/AddNamespaceGroupsCore.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Ddue.Tools
                 // there already.  A group is only created if it will contain more than one namespace. Namespaces
                 // without any children will end up in their parent as a standard namespace entry.
                 if(root.Length > 2 && !groups.ContainsKey(root) &&
-                  namespaces.Count(n => n.StartsWith(root + ".", StringComparison.Ordinal)) > 1)
+                  namespaces.Count(n => n.StartsWith(root, StringComparison.Ordinal)) > 1)
                     groups.Add(root, new NamespaceGroup { Namespace = root });
             }
 


### PR DESCRIPTION
AddNamespaceGroups plugin: [fix] include the root namespace in the count of potential namespaces in the group.

Considering the following namespaces:
MyCompany.MyProduct.Module1
MyCompany.MyProduct.Module1.Feature
MyCompany.MyProduct.Module2
MyCompany.MyProduct.Module2.Feature1
MyCompany.MyProduct.Module2.Feature2

A namespace group will be created for MyCompany.MyProduct.Module2 but not
for MyCompany.MyProduct.Module1
This fix allows to create a group for each.