### PR TITLE
Correct init of dict

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
+++ b/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
@@ -421,7 +421,7 @@ function PerformSearch()
     });
 
     var letters = [];
-    var wordDictionary = [];
+    var wordDictionary = {};
     var wordNotFound = false;
 
     // Load the keyword files for each keyword starting letter


### PR DESCRIPTION
otherwise crash when wordDictionary["length"]= "asdads"

closes #100