### PR TITLE
Distinguish SHFB completions from others without reflection trickery

### DIFF
--- a/SHFB/Source/SandcastleBuilderPackage/IntelliSense/CSharpDocumentationCompletionSource.cs
+++ b/SHFB/Source/SandcastleBuilderPackage/IntelliSense/CSharpDocumentationCompletionSource.cs
@@ -122,7 +122,7 @@ namespace SandcastleBuilder.Package.IntelliSense
                     "This element is used to create a link to a MAML topic within the See Also section of a " +
                     "topic or an inline link to a MAML topic within one of the other XML comments elements.",
                     iconSource, ""),
-                new Completion("inheritdoc", prefix + "inheritdoc/>", "This element can help minimize the " +
+                new SandcastleCompletion("inheritdoc", prefix + "inheritdoc/>", "This element can help minimize the " +
                     "effort required to document complex APIs by allowing common documentation to be " +
                     "inherited from base types/members.", iconSource, ""),
                 new CustomCompletion(session, "inheritdoc cref", prefix + "inheritdoc cref=\"\xFF\"/>",
@@ -130,7 +130,7 @@ namespace SandcastleBuilder.Package.IntelliSense
                 new CustomCompletion(session, "inheritdoc cref/select", prefix + "inheritdoc cref=\"\xFF\" " +
                     "select=\"summary|remarks\"/>", "Inherit documentation from a specific member and comments.",
                     iconSource, ""),
-                new Completion("token", prefix + "token", "This element represents a replaceable tag within " +
+                new SandcastleCompletion("token", prefix + "token", "This element represents a replaceable tag within " +
                     "a topic.", iconSource, "")
             };
 
@@ -138,23 +138,23 @@ namespace SandcastleBuilder.Package.IntelliSense
             if(allTags.Contains("exception"))
                 completions.AddRange(new[]
                 {
-                    new Completion("AttachedEventComments", prefix + "AttachedEventComments", "This element " +
+                    new SandcastleCompletion("AttachedEventComments", prefix + "AttachedEventComments", "This element " +
                         "is used to define the content that should appear on the auto-generated attached " +
                         "event member topic for a given WPF routed event member.", iconSource, ""),
-                    new Completion("AttachedPropertyComments", prefix + "AttachedPropertyComments",
+                    new SandcastleCompletion("AttachedPropertyComments", prefix + "AttachedPropertyComments",
                         "This element is used to define the content that should appear on the auto-generated " +
                         "attached property member topic for a given WPF dependency property member.",
                         iconSource, ""),
                     new CustomCompletion(session, "event", prefix + "event cref=\"\xFF\"",
                         "This element is used to list events that can be raised by a type's member.",
                         iconSource, ""),
-                    new Completion("overloads", prefix + "overloads", "This element is used to define the " +
+                    new SandcastleCompletion("overloads", prefix + "overloads", "This element is used to define the " +
                         "content that should appear on the auto-generated overloads topic for a given set of " +
                         "member overloads.", iconSource, ""),
-                    new Completion("preliminary", prefix + "preliminary/>",
+                    new SandcastleCompletion("preliminary", prefix + "preliminary/>",
                         "This element is used to indicate that a particular type or member is preliminary and " +
                         "is subject to change.", iconSource, ""),
-                    new Completion("threadsafety", prefix + "threadsafety static=\"true\" instance=\"false\"/>",
+                    new SandcastleCompletion("threadsafety", prefix + "threadsafety static=\"true\" instance=\"false\"/>",
                         "This element is used to indicate whether or not a class or structure's static and " +
                         "instance members are safe for use in multi-threaded scenarios.", iconSource, "")
                 });
@@ -164,7 +164,7 @@ namespace SandcastleBuilder.Package.IntelliSense
             {
                 completions.AddRange(new[]
                 {
-                    new Completion("note", prefix + "note type=\"note\"", "This element is used to create a " +
+                    new SandcastleCompletion("note", prefix + "note type=\"note\"", "This element is used to create a " +
                         "note-like section within a topic to draw attention to some important information.",
                         iconSource, "")
                 });
@@ -173,23 +173,23 @@ namespace SandcastleBuilder.Package.IntelliSense
                 // Sandcastle only uses them if they are inline.
                 completions.AddRange(new[]
                 {
-                    new Completion("null", prefix + "see langword=\"null\"/>", "Inserts the language-specific " +
+                    new SandcastleCompletion("null", prefix + "see langword=\"null\"/>", "Inserts the language-specific " +
                         "keyword 'null'.", macroIconSource, ""),
-                    new Completion("static", prefix + "see langword=\"static\"/>", "Inserts the " +
+                    new SandcastleCompletion("static", prefix + "see langword=\"static\"/>", "Inserts the " +
                         "language-specific keyword 'static'.", macroIconSource, ""),
-                    new Completion("virtual", prefix + "see langword=\"virtual\"/>", "Inserts the " +
+                    new SandcastleCompletion("virtual", prefix + "see langword=\"virtual\"/>", "Inserts the " +
                         "language-specific keyword 'virtual'.", macroIconSource, ""),
-                    new Completion("true", prefix + "see langword=\"true\"/>", "Inserts the language-specific " +
+                    new SandcastleCompletion("true", prefix + "see langword=\"true\"/>", "Inserts the language-specific " +
                         "keyword 'true'.", macroIconSource, ""),
-                    new Completion("false", prefix + "see langword=\"false\"/>", "Inserts the " +
+                    new SandcastleCompletion("false", prefix + "see langword=\"false\"/>", "Inserts the " +
                         "language-specific keyword 'false'.", macroIconSource, ""),
-                    new Completion("abstract", prefix + "see langword=\"abstract\"/>", "Inserts the " +
+                    new SandcastleCompletion("abstract", prefix + "see langword=\"abstract\"/>", "Inserts the " +
                         "language-specific keyword 'abstract'.", macroIconSource, ""),
-                    new Completion("async", prefix + "see langword=\"async\"/>", "Inserts the " +
+                    new SandcastleCompletion("async", prefix + "see langword=\"async\"/>", "Inserts the " +
                         "language-specific keyword 'async'.", macroIconSource, ""),
-                    new Completion("await", prefix + "see langword=\"await\"/>", "Inserts the " +
+                    new SandcastleCompletion("await", prefix + "see langword=\"await\"/>", "Inserts the " +
                         "language-specific keyword 'await'.", macroIconSource, ""),
-                    new Completion("async/await", prefix + "see langword=\"async/await\"/>", "Inserts the " +
+                    new SandcastleCompletion("async/await", prefix + "see langword=\"async/await\"/>", "Inserts the " +
                         "language-specific keyword 'async/await'.", macroIconSource, "")
                 });
             }

--- a/SHFB/Source/SandcastleBuilderPackage/IntelliSense/CustomCompletion.cs
+++ b/SHFB/Source/SandcastleBuilderPackage/IntelliSense/CustomCompletion.cs
@@ -31,11 +31,11 @@ namespace SandcastleBuilder.Package.IntelliSense
     /// Represents a completion item, including the icon, insertion text, and display text, in a CompletionSet.
     /// </summary>
     /// <remarks>
-    /// This class extends the <see cref="Completion"/> class by allowing the <see cref="Completion.InsertionText"/>
-    /// to contain a <c>\xFF</c> character to represent the placement of the caret after the completion is
-    /// inserted into the editor.
+    /// This class extends the <see cref="SandcastleCompletion"/> class by allowing the
+    /// <see cref="Completion.InsertionText"/> to contain a <c>\xFF</c> character to represent the placement of the
+    /// caret after the completion is inserted into the editor.
     /// </remarks>
-    internal sealed class CustomCompletion : Completion, ICustomCommit
+    internal sealed class CustomCompletion : SandcastleCompletion, ICustomCommit
     {
         private readonly ICompletionSession session;
 

--- a/SHFB/Source/SandcastleBuilderPackage/IntelliSense/RoslynHacks/RoslynKeyboardFilter.cs
+++ b/SHFB/Source/SandcastleBuilderPackage/IntelliSense/RoslynHacks/RoslynKeyboardFilter.cs
@@ -109,9 +109,9 @@ namespace SandcastleBuilder.Package.IntelliSense.RoslynHacks
 
             CompletionSet completionSet = completionSession.SelectedCompletionSet;
             CompletionSelectionStatus selectionStatus = completionSet.SelectionStatus;
-            if (selectionStatus.Completion.GetType().Name == "CustomCommitCompletion")
+            if (!(selectionStatus.Completion is SandcastleCompletion))
             {
-                // let Roslyn handle its own completions
+                // let other providers handle their own completions
                 return false;
             }
 

--- a/SHFB/Source/SandcastleBuilderPackage/IntelliSense/SandcastleCompletion.cs
+++ b/SHFB/Source/SandcastleBuilderPackage/IntelliSense/SandcastleCompletion.cs
@@ -1,0 +1,68 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Help File Builder Visual Studio Package
+// File    : SandcastleCompletion.cs
+// Author  : Sam Harwell  (sam@tunnelvisionlabs.com)
+// Updated : 07/15/2015
+// Note    : Copyright 2015, Sam Harwell, All rights reserved
+// Compiler: Microsoft Visual C#
+//
+// This file contains a custom completion class which is distinguishable from the Completion class provided by the
+// Visual Studio SDK.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code.  It can also be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 07/15/2015  SCH  Initial implementation.
+//===============================================================================================================
+
+using System.Windows.Media;
+
+using Microsoft.VisualStudio.Language.Intellisense;
+
+namespace SandcastleBuilder.Package.IntelliSense
+{
+    /// <summary>
+    /// Represents a completion item, including the icon, insertion text, and display text, in a
+    /// <see cref="CompletionSet"/>.
+    /// </summary>
+    /// <remarks>
+    /// This class extends the <see cref="Completion"/> class, allowing the SHFB editor extensions to distinguish
+    /// between completion items provided by SHFB, and those provided by other packages.
+    /// </remarks>
+    internal class SandcastleCompletion : Completion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SandcastleCompletion"/> class.
+        /// </summary>
+        public SandcastleCompletion()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SandcastleCompletion"/> class with the specified display text.
+        /// </summary>
+        /// <param name="displayText">The text that is to be displayed by an IntelliSense presenter.</param>
+        public SandcastleCompletion(string displayText) : base(displayText)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SandcastleCompletion"/> class with the specified text and
+        /// description.
+        /// </summary>
+        /// <param name="displayText">The text that is to be displayed by an IntelliSense presenter.</param>
+        /// <param name="insertionText">The text that is to be inserted into the buffer if this completion is committed.</param>
+        /// <param name="description">A description that can be displayed with the display text of the completion.</param>
+        /// <param name="iconSource">The icon.</param>
+        /// <param name="iconAutomationText">The text to be used as the automation name for the icon.</param>
+        public SandcastleCompletion(string displayText, string insertionText, string description, ImageSource iconSource, string iconAutomationText)
+            : base(displayText, insertionText, description, iconSource, iconAutomationText)
+        {
+        }
+    }
+}

--- a/SHFB/Source/SandcastleBuilderPackage/SandcastleBuilderPackage.csproj
+++ b/SHFB/Source/SandcastleBuilderPackage/SandcastleBuilderPackage.csproj
@@ -188,6 +188,7 @@
     <Compile Include="IntelliSense\RoslynHacks\TextViewCommandFilter.cs" />
     <Compile Include="IntelliSense\RoslynHacks\ToolTipProvider.cs" />
     <Compile Include="IntelliSense\RoslynHacks\WpfHelper.cs" />
+    <Compile Include="IntelliSense\SandcastleCompletion.cs" />
     <Compile Include="MefProviderOptions.cs" />
     <Compile Include="PropertyPages\BuildEventEditorForm.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
Rather than look for another provider's completions by a specific type name, identify our own instead.