### PR TITLE
Issue 180

### DIFF
--- a/Documentation/XMLCommentsGuide/Content/InlineElements/see.aml
+++ b/Documentation/XMLCommentsGuide/Content/InlineElements/see.aml
@@ -89,6 +89,7 @@ the tooltip.</para>
 <code language="xml" title=" ">
 &lt;see langword="null | Nothing | nullptr | static | shared | virtual |
     Overridable | true | True | false | False | abstract | MustInherit |
+    sealed | NotInheritable |
     async | await | async/await | Async | Await | Async/Await | let! |
     async/let!" /&gt;
 </code>

--- a/SHFB/Source/PresentationStyles/Markdown/Content/SharedContent.xml
+++ b/SHFB/Source/PresentationStyles/Markdown/Content/SharedContent.xml
@@ -63,6 +63,7 @@
 	<item id="devlang_trueKeyword">`true` (`True` in Visual Basic)</item>
 	<item id="devlang_falseKeyword">`false` (`False` in Visual Basic)</item>
 	<item id="devlang_abstractKeyword">`abstract` (`MustInherit` in Visual Basic)</item>
+	<item id="devlang_sealedKeyword">`sealed` (`NotInheritable` in Visual Basic)</item>
 	<item id="devlang_asyncKeyword">`async` (`Async` in Visual Basic)</item>
 	<item id="devlang_awaitKeyword">`await` (`Await` in Visual Basic)</item>
 	<item id="devlang_asyncAwaitKeyword">`async`/`await` (`Async`/`Await` in Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/Markdown/Content/ru-RU/SharedContent.xml
+++ b/SHFB/Source/PresentationStyles/Markdown/Content/ru-RU/SharedContent.xml
@@ -61,6 +61,7 @@
   <item id="devlang_trueKeyword">`true` (`True` в Visual Basic)</item>
   <item id="devlang_falseKeyword">`false` (`False` в Visual Basic)</item>
   <item id="devlang_abstractKeyword">`abstract` (`MustInherit` в Visual Basic)</item>
+  <item id="devlang_sealedKeyword">`sealed` (`NotInheritable` в Visual Basic)</item>
 
   <!-- Back to Top link text -->
   <item id="top">В начало страницы</item>

--- a/SHFB/Source/PresentationStyles/Markdown/Transforms/MAMLTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/Markdown/Transforms/MAMLTemplates.xsl
@@ -905,6 +905,9 @@
 			<xsl:when test="$v_keyword='abstract' or $v_keyword='MustInherit'">
 				<include item="devlang_abstractKeyword"/>
 			</xsl:when>
+			<xsl:when test="$v_keyword='sealed' or $v_keyword='NotInheritable'">
+				<include item="devlang_sealedKeyword"/>
+			</xsl:when>
 			<xsl:when test="$v_keyword='async' or $v_keyword='Async'">
 				<include item="devlang_asyncKeyword"/>
 			</xsl:when>

--- a/SHFB/Source/PresentationStyles/Markdown/Transforms/MainSandcastle.xsl
+++ b/SHFB/Source/PresentationStyles/Markdown/Transforms/MainSandcastle.xsl
@@ -1024,6 +1024,9 @@
 			<xsl:when test="@langword='abstract' or @langword='MustInherit'">
 				<include item="devlang_abstractKeyword"/>
 			</xsl:when>
+			<xsl:when test="$v_keyword='sealed' or @langword='NotInheritable'">
+				<include item="devlang_sealedKeyword"/>
+			</xsl:when>
 			<xsl:when test="@langword='async' or @langword='async'">
 				<include item="devlang_asyncKeyword"/>
 			</xsl:when>

--- a/SHFB/Source/PresentationStyles/OpenXml/Content/SharedContent.xml
+++ b/SHFB/Source/PresentationStyles/OpenXml/Content/SharedContent.xml
@@ -62,6 +62,7 @@
 	<item id="devlang_trueKeyword"><span class="CodeInline">true</span> (<span class="CodeInline">True</span> in Visual Basic)</item>
 	<item id="devlang_falseKeyword"><span class="CodeInline">false</span> (<span class="CodeInline">False</span> in Visual Basic)</item>
 	<item id="devlang_abstractKeyword"><span class="CodeInline">abstract</span> (<span class="CodeInline">MustInherit</span> in Visual Basic)</item>
+	<item id="devlang_sealedKeyword"><span class="CodeInline">sealed</span> (<span class="CodeInline">NotInheritable</span> in Visual Basic)</item>
 
 	<!-- Back to Top link text -->
 	<item id="top">Back to Top</item>

--- a/SHFB/Source/PresentationStyles/OpenXml/Content/ru-RU/SharedContent.xml
+++ b/SHFB/Source/PresentationStyles/OpenXml/Content/ru-RU/SharedContent.xml
@@ -63,6 +63,7 @@
   <item id="devlang_trueKeyword"><span class="CodeInline">true</span> (<span class="CodeInline">True</span> в Visual Basic)</item>
   <item id="devlang_falseKeyword"><span class="CodeInline">false</span> (<span class="CodeInline">False</span> в Visual Basic)</item>
   <item id="devlang_abstractKeyword"><span class="CodeInline">abstract</span> (<span class="CodeInline">MustInherit</span> в Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="CodeInline">sealed</span> (<span class="CodeInline">NotInheritable</span> в Visual Basic)</item>
 
   <!-- Back to Top link text -->
   <item id="top">В начало страницы</item>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/MAMLTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/MAMLTemplates.xsl
@@ -947,6 +947,9 @@
 			<xsl:when test="$v_keyword='abstract' or $v_keyword='MustInherit'">
 				<include item="devlang_abstractKeyword"/>
 			</xsl:when>
+			<xsl:when test="$v_keyword='sealed' or $v_keyword='NotInheritable'">
+				<include item="devlang_sealedKeyword"/>
+			</xsl:when>
 			<xsl:otherwise>
 				<w:r>
 					<w:rPr>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/MainSandcastle.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/MainSandcastle.xsl
@@ -1098,6 +1098,9 @@
 			<xsl:when test="@langword='abstract' or @langword='MustInherit'">
 				<include item="devlang_abstractKeyword"/>
 			</xsl:when>
+			<xsl:when test="@langword='sealed' or @langword='NotInheritable'">
+				<include item="devlang_sealedKeyword"/>
+			</xsl:when>
 			<xsl:when test="@langword='async' or @langword='async'">
 				<include item="devlang_asyncKeyword"/>
 			</xsl:when>

--- a/SHFB/Source/PresentationStyles/VS2010/Content/de-DE/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2010/Content/de-DE/shared_content.xml
@@ -102,6 +102,7 @@
   <item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> in Visual Basic)</item>
   <item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> in Visual Basic)</item>
   <item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> in Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> in Visual Basic)</item>
   <item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> in Visual Basic)</item>
   <item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> in Visual Basic)</item>
   <item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> in Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2010/Content/ru-RU/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2010/Content/ru-RU/shared_content.xml
@@ -103,6 +103,7 @@
   <item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> в Visual Basic)</item>
   <item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> в Visual Basic)</item>
   <item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> в Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> в Visual Basic)</item>
   <item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> в Visual Basic)</item>
   <item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> в Visual Basic)</item>
   <item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> в Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2010/Content/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2010/Content/shared_content.xml
@@ -101,6 +101,7 @@
 	<item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> in Visual Basic)</item>
 	<item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> in Visual Basic)</item>
 	<item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> in Visual Basic)</item>
+	<item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> in Visual Basic)</item>
 	<item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> in Visual Basic)</item>
 	<item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> in Visual Basic)</item>
 	<item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> in Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2010/Transforms/globalTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/VS2010/Transforms/globalTemplates.xsl
@@ -234,7 +234,26 @@
 		</xsl:choose>
 	</xsl:template>
 
-	<xsl:template name="t_inKeyword">
+	<xsl:template name="t_sealedKeyword">
+		<xsl:param name="p_syntaxKeyword" select="''"/>
+		<xsl:choose>
+			<xsl:when test="$p_syntaxKeyword">
+				<span class="keyword">
+					<span class="languageSpecificText">
+						<span class="vb">NotInheritable</span>
+						<span class="nu">sealed</span>
+					</span>
+				</span>
+			</xsl:when>
+			<xsl:otherwise>
+				<span>
+					<include item="devlang_sealedKeyword"/>
+				</span>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+  <xsl:template name="t_inKeyword">
 		<span class="keyword">
 			<span class="languageSpecificText">
 				<span class="vb">In</span>

--- a/SHFB/Source/PresentationStyles/VS2010/Transforms/globalTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/VS2010/Transforms/globalTemplates.xsl
@@ -253,7 +253,7 @@
 		</xsl:choose>
 	</xsl:template>
 
-  <xsl:template name="t_inKeyword">
+	<xsl:template name="t_inKeyword">
 		<span class="keyword">
 			<span class="languageSpecificText">
 				<span class="vb">In</span>

--- a/SHFB/Source/PresentationStyles/VS2010/Transforms/main_sandcastle.xsl
+++ b/SHFB/Source/PresentationStyles/VS2010/Transforms/main_sandcastle.xsl
@@ -1102,6 +1102,11 @@
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
 				</xsl:call-template>
 			</xsl:when>
+			<xsl:when test="@langword='sealed' or @langword='NotInheritable'">
+				<xsl:call-template name="t_sealedKeyword">
+					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
+				</xsl:call-template>
+			</xsl:when>
 			<xsl:when test="@langword='async' or @langword='Async'">
 				<xsl:call-template name="t_asyncKeyword">
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>

--- a/SHFB/Source/PresentationStyles/VS2010/Transforms/utilities_dduexml.xsl
+++ b/SHFB/Source/PresentationStyles/VS2010/Transforms/utilities_dduexml.xsl
@@ -1082,6 +1082,11 @@
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
 				</xsl:call-template>
 			</xsl:when>
+			<xsl:when test="$v_keyword='sealed' or $v_keyword='NotInheritable'">
+				<xsl:call-template name="t_sealedKeyword">
+					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
+				</xsl:call-template>
+			</xsl:when>
 			<xsl:when test="$v_keyword='async' or $v_keyword='Async'">
 				<xsl:call-template name="t_asyncKeyword">
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>

--- a/SHFB/Source/PresentationStyles/VS2013/Content/de-DE/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2013/Content/de-DE/shared_content.xml
@@ -102,6 +102,7 @@
   <item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> in Visual Basic)</item>
   <item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> in Visual Basic)</item>
   <item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> in Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> in Visual Basic)</item>
   <item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> in Visual Basic)</item>
   <item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> in Visual Basic)</item>
   <item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> in Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2013/Content/es-ES/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2013/Content/es-ES/shared_content.xml
@@ -102,6 +102,7 @@
 	<item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> en Visual Basic)</item>
 	<item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> en Visual Basic)</item>
 	<item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> en Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> en Visual Basic)</item>
 	<item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> en Visual Basic)</item>
 	<item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> en Visual Basic)</item>
 	<item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> en Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2013/Content/fr-FR/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2013/Content/fr-FR/shared_content.xml
@@ -102,6 +102,7 @@
 	<item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> en Visual Basic)</item>
 	<item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> en Visual Basic)</item>
 	<item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> en Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> en Visual Basic)</item>
 	<item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> en Visual Basic)</item>
 	<item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> en Visual Basic)</item>
 	<item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> en Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2013/Content/ru-RU/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2013/Content/ru-RU/shared_content.xml
@@ -103,6 +103,7 @@
   <item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> в Visual Basic)</item>
   <item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> в Visual Basic)</item>
   <item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> в Visual Basic)</item>
+  <item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> в Visual Basic)</item>
   <item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> в Visual Basic)</item>
   <item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> в Visual Basic)</item>
   <item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> в Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2013/Content/shared_content.xml
+++ b/SHFB/Source/PresentationStyles/VS2013/Content/shared_content.xml
@@ -101,6 +101,7 @@
 	<item id="devlang_trueKeyword"><span class="keyword">true</span> (<span class="keyword">True</span> in Visual Basic)</item>
 	<item id="devlang_falseKeyword"><span class="keyword">false</span> (<span class="keyword">False</span> in Visual Basic)</item>
 	<item id="devlang_abstractKeyword"><span class="keyword">abstract</span> (<span class="keyword">MustInherit</span> in Visual Basic)</item>
+	<item id="devlang_sealedKeyword"><span class="keyword">sealed</span> (<span class="keyword">NotInheritable</span> in Visual Basic)</item>
 	<item id="devlang_asyncKeyword"><span class="keyword">async</span> (<span class="keyword">Async</span> in Visual Basic)</item>
 	<item id="devlang_awaitKeyword"><span class="keyword">await</span> (<span class="keyword">Await</span> in Visual Basic)</item>
 	<item id="devlang_asyncAwaitKeyword"><span class="keyword">async</span>/<span class="keyword">await</span> (<span class="keyword">Async</span>/<span class="keyword">Await</span> in Visual Basic)</item>

--- a/SHFB/Source/PresentationStyles/VS2013/Transforms/globalTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/VS2013/Transforms/globalTemplates.xsl
@@ -234,6 +234,25 @@
 		</xsl:choose>
 	</xsl:template>
 
+	<xsl:template name="t_sealedKeyword">
+		<xsl:param name="p_syntaxKeyword" select="''"/>
+		<xsl:choose>
+			<xsl:when test="$p_syntaxKeyword">
+				<span class="keyword">
+					<span class="languageSpecificText">
+						<span class="vb">NotInheritable</span>
+						<span class="nu">sealed</span>
+					</span>
+				</span>
+			</xsl:when>
+			<xsl:otherwise>
+				<span>
+					<include item="devlang_sealedKeyword"/>
+				</span>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
 	<xsl:template name="t_inKeyword">
 		<span class="keyword">
 			<span class="languageSpecificText">

--- a/SHFB/Source/PresentationStyles/VS2013/Transforms/main_sandcastle.xsl
+++ b/SHFB/Source/PresentationStyles/VS2013/Transforms/main_sandcastle.xsl
@@ -1096,6 +1096,11 @@
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
 				</xsl:call-template>
 			</xsl:when>
+			<xsl:when test="@langword='sealed' or @langword='NotInheritable'">
+				<xsl:call-template name="t_sealedKeyword">
+					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
+				</xsl:call-template>
+			</xsl:when>
 			<xsl:when test="@langword='async' or @langword='Async'">
 				<xsl:call-template name="t_asyncKeyword">
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>

--- a/SHFB/Source/PresentationStyles/VS2013/Transforms/utilities_dduexml.xsl
+++ b/SHFB/Source/PresentationStyles/VS2013/Transforms/utilities_dduexml.xsl
@@ -1080,6 +1080,11 @@
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
 				</xsl:call-template>
 			</xsl:when>
+			<xsl:when test="$v_keyword='sealed' or $v_keyword='NotInheritable'">
+				<xsl:call-template name="t_sealedKeyword">
+					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>
+				</xsl:call-template>
+			</xsl:when>
 			<xsl:when test="$v_keyword='async' or $v_keyword='Async'">
 				<xsl:call-template name="t_asyncKeyword">
 					<xsl:with-param name="p_syntaxKeyword" select="$v_syntaxKeyword"/>


### PR DESCRIPTION
Looked for anywhere that "abstract" was used and added corresponding code for "sealed".

Tested with VS2013 presentation style.