### PR TITLE
Fixes/227 lightweight website style plug in

### DIFF
--- a/SHFB/Source/SandcastleBuilderPlugIns/LightweightWebsiteStylePlugIn.cs
+++ b/SHFB/Source/SandcastleBuilderPlugIns/LightweightWebsiteStylePlugIn.cs
@@ -183,7 +183,7 @@ namespace SandcastleBuilder.PlugIns
                     }
                 }
 
-                if(copy.Attribute("Url") == null)
+                if(string.IsNullOrEmpty((string)copy.Attribute("Url")))
                     continue;
 
                 // Generate the lightweight TOC pane
@@ -268,7 +268,7 @@ namespace SandcastleBuilder.PlugIns
                         tocNav,
                         resizableBar,
                         resizeUi);
-
+                
                 string path = Path.Combine(builder.WorkingFolder, @"Output\Website", current.Attribute("Url").Value);
                 string outputFile = File.ReadAllText(path, Encoding.UTF8);
 

--- a/SHFB/Source/SandcastleBuilderPlugIns/LightweightWebsiteStylePlugIn.cs
+++ b/SHFB/Source/SandcastleBuilderPlugIns/LightweightWebsiteStylePlugIn.cs
@@ -268,7 +268,7 @@ namespace SandcastleBuilder.PlugIns
                         tocNav,
                         resizableBar,
                         resizeUi);
-                
+
                 string path = Path.Combine(builder.WorkingFolder, @"Output\Website", current.Attribute("Url").Value);
                 string outputFile = File.ReadAllText(path, Encoding.UTF8);
 


### PR DESCRIPTION
Check whether the value of `copy.Attribute("Url")` is null or an empty string; cast the attribute to a string to get the attribute value and then using `string.IsNullOrEmpty`