### PR TITLE
Allow configuration of dependency property & routed event types

### DIFF
--- a/SHFB/Source/MRefBuilder/XamlAttachedMembersAddIn.cs
+++ b/SHFB/Source/MRefBuilder/XamlAttachedMembersAddIn.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Ddue.Tools
                         if(!name.EndsWith(dependencyPropertySuffix, StringComparison.Ordinal))
                             continue;
 
-                        name = name.Substring(0, name.Length - 8);
+                        name = name.Substring(0, name.Length - dependencyPropertySuffix.Length);
 
                         // Look for a getter and/or a setter
                         Method getter = null;
@@ -177,7 +177,7 @@ namespace Microsoft.Ddue.Tools
                         if(!name.EndsWith(routedEventSuffix, StringComparison.Ordinal))
                             continue;
 
-                        name = name.Substring(0, name.Length - 5);
+                        name = name.Substring(0, name.Length - routedEventSuffix.Length);
 
                         Method adder = null;
 


### PR DESCRIPTION
I'm the maintainer of a [game development framework](https://github.com/tlgkccampbell/ultraviolet) which has its own implementation of dependency objects. My implementation is similar enough to Microsoft's that I would like to document them in the same way, but MRefBuilder is hard-coded to recognize dependency properties by looking at the fully-qualified type name of the identifier field. Since my implementation is in its own namespace, my attached properties and events don't show up in my Sandcastle docs.

This PR makes the `XamlAttachedMembersAddIn` class configurable via project properties, so that a project can override the previously hard-coded defaults.
