### PR TITLE
#243 - Added a dash '-' to the allowed set of characters on the query string of direct links

### DIFF
--- a/SHFB/Source/PresentationStyles/LegacyWeb/TOC.js
+++ b/SHFB/Source/PresentationStyles/LegacyWeb/TOC.js
@@ -96,7 +96,7 @@ function Initialize(extension)
             if(options[idx] == "topic" && idx + 1 < options.length)
             {
                 // Don't allow javascript, or references outside the current site
-                if(options[idx + 1].match(/^\w[\w\/.]*$/))
+                if(options[idx + 1].match(/^\w[\w\/.-]*$/))
                     topicContent.src = options[idx + 1];
                 break;
             }


### PR DESCRIPTION
Direct links are broken in legacy styles because the topics have guids in the address with dashes and the current regular expression does not allow dashes.  This change adds dashes to the white-list of characters allowed on the query string to fix this issue.