### PR TITLE
Fixed #283: Parse version strings to Version for sorting

### DIFF
--- a/SHFB/Source/SandcastleBuilderPlugIns/VersionSettingsCollection.cs
+++ b/SHFB/Source/SandcastleBuilderPlugIns/VersionSettingsCollection.cs
@@ -107,8 +107,15 @@ namespace SandcastleBuilder.PlugIns
                     false, CultureInfo.CurrentCulture);
 
                 if(result == 0)
-                    result = String.Compare(x.Version, y.Version,
-                        false, CultureInfo.CurrentCulture) * -1;
+                {
+                    Version versionX, versionY;
+
+                    if(Version.TryParse(x.Version, out versionX) && Version.TryParse(y.Version, out versionY))
+                        result = versionY.CompareTo(versionX);
+                    else
+                        result = String.Compare(x.Version, y.Version,
+                            false, CultureInfo.CurrentCulture)*-1;
+                }
 
                 return result;
             });


### PR DESCRIPTION
Replaced current behavior of using string comparison for sorting versions by trying to parse the version string to Version types and then comparing the result.

Will fallback to current behavior if unable to parse the version string.