### PR TITLE
Fixed bug when documenting a constructor with generic arguments, the …

### DIFF
--- a/SHFB/Source/MRefBuilder/Reflection/OrcasNamer.cs
+++ b/SHFB/Source/MRefBuilder/Reflection/OrcasNamer.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Ddue.Tools.Reflection
                         {
                             // Number of parameters
                             TypeNodeList parameters = type.TemplateParameters;
-
                             if(parameters != null)
                             {
                                 sb.Append('`');
@@ -192,9 +191,14 @@ namespace Microsoft.Ddue.Tools.Reflection
 
                             // Arguments
                             TypeNodeList arguments = type.TemplateArguments;
-
                             if(arguments != null && arguments.Count > 0)
                             {
+                                if (parameters == null)
+                                {
+                                    sb.Append('`');
+                                    sb.Append(arguments.Count);
+                                }
+
                                 sb.Append("{");
 
                                 for(int i = 0; i < arguments.Count; i++)


### PR DESCRIPTION
…reflection xml was wrong. This results an ShowMissingComponent warning due not more matching XML files.