### PR TITLE
Dynamic msbuild properties during VS build

### DIFF
--- a/SHFB/Source/SandcastleBuilderUtils/SandcastleHelpFileBuilder.targets
+++ b/SHFB/Source/SandcastleBuilderUtils/SandcastleHelpFileBuilder.targets
@@ -38,9 +38,10 @@
 	<!-- The Core Build Help target -->
 	<Target Name="CoreBuildHelp">
 		<SandcastleBuilder.Utils.MSBuild.BuildHelp
-				ProjectFile="$(MSBuildProjectFullPath)"
+        ProjectFile="$(MSBuildProjectFullPath)"
 				Configuration="$(Configuration)"
 				Platform="$(Platform)"
+        Properties="$(SubstitutionTags)"
 				OutDir="$(OutDir)"
 				Verbose="$(Verbose)"
 				DumpLogOnFailure="$(DumpLogOnFailure)"


### PR DESCRIPTION
Added support for _dynamic_ `msbuild` properties during Visual Studio build.
Previously, during VS build, properties set during `msbuild` targets where not available to the build task, when executed from VS. Here the project file was loaded, and only the static properties where available.

Now it is possible to implement custom targets which create/set properties, and make them available during SHFB tag substitution. (This previously only worked when executing `msbuild` directly, and not from solution build)

I use this to update the `HelpFileVersion` and some other text, and bind it against a specific git commit during build.

in the `.shfbproj` I can now add some custom targets:
```
<PropertyGroup>
    <BuildDependsOn>
      GetBuildGitVersion;
      $(BuildDependsOn)
    </BuildDependsOn>
  </PropertyGroup>

<Target Name="GetBuildGitVersion" Returns="$(BuildVersion)">

    <Message Importance="high" Text="running GetBuildGitVersion" />
    
    <Nerdbank.GitVersioning.Tasks.GetBuildVersion
      BuildingRef="$(_NBGV_BuildingRef)"
      BuildMetadata="@(BuildMetadata)"
      DefaultPublicRelease="$(PublicRelease)"
      GitRepoRoot="$(GitRepoRoot)">

      <Output TaskParameter="Version" PropertyName="BuildVersion" />
      <Output TaskParameter="AssemblyInformationalVersion" PropertyName="HelpInformationalVersion" />
      <Output TaskParameter="AssemblyFileVersion" PropertyName="HelpFileVersion" />
      <Output TaskParameter="SimpleVersion" PropertyName="BuildVersionSimple" />
      <Output TaskParameter="PrereleaseVersion" PropertyName="PrereleaseVersion" />
      <Output TaskParameter="MajorMinorVersion" PropertyName="MajorMinorVersion" />
      <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
      <Output TaskParameter="GitCommitId" PropertyName="GitCommitId" />
      <Output TaskParameter="GitCommitIdShort" PropertyName="GitCommitIdShort" />
      <Output TaskParameter="GitVersionHeight" PropertyName="GitVersionHeight" />
      <Output TaskParameter="BuildNumber" PropertyName="BuildNumber" />
      <Output TaskParameter="BuildNumber" PropertyName="BuildVersionNumberComponent" />
      <Output TaskParameter="PublicRelease" PropertyName="PublicRelease" />
      <Output TaskParameter="CloudBuildNumber" PropertyName="CloudBuildNumber" Condition=" '$(CloudBuildNumber)' == '' "/>
      <Output TaskParameter="BuildMetadataFragment" PropertyName="SemVerBuildSuffix" />
      <Output TaskParameter="NuGetPackageVersion" PropertyName="NuGetPackageVersion" />
      <Output TaskParameter="NPMPackageVersion" PropertyName="NPMPackageVersion" />
      <Output TaskParameter="CloudBuildVersionVars" ItemName="CloudBuildVersionVars" />
    </Nerdbank.GitVersioning.Tasks.GetBuildVersion>

    <Warning Condition=" '$(HelpInformationalVersion)' == '' " Text="Unable to determine the git HEAD commit ID to use for informational version number." />
    <Message Condition=" '$(HelpInformationalVersion)' != '' " Text="Building version $(BuildVersion) from commit $(GitCommitId)"/>
    <Message Condition=" '$(HelpInformationalVersion)' == '' " Text="Building version $(BuildVersion)"/>
    <Message Text="HelpFileVersion: $(HelpFileVersion)" />
    <Message Text="HelpInformationalVersion: $(HelpInformationalVersion)" />

	<PropertyGroup>
		<SubstitutionTags>$(SubstitutionTags);HelpInformationalVersion=$(HelpInformationalVersion);HelpFileVersion=$(HelpFileVersion);Version=$(BuildVersion);GitCommitId=$(GitCommitId);</SubstitutionTags>
	</PropertyGroup>
  </Target>
```