### PR TITLE
Fix invalid DOCTYPE in generated hhc files according to the CHM specification

### DIFF
--- a/SHFB/Source/SandcastleHtmlExtract/SandcastleHtmlExtract.cs
+++ b/SHFB/Source/SandcastleHtmlExtract/SandcastleHtmlExtract.cs
@@ -782,7 +782,7 @@ commas, or other special characters.
                 using(StreamWriter writer = new StreamWriter(Path.Combine(outputFolder, projectName + ".hhc"), false,
                   Encoding.GetEncoding(codePage)))
                 {
-                    writer.WriteLine("<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML/EN\">\r\n");
+                    writer.WriteLine("<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML//EN\">\r\n");
                     writer.WriteLine("<HTML>");
                     writer.WriteLine("  <BODY>");
 


### PR DESCRIPTION
This "new", correct DOCTYPE is also found in many CHM files not generated by SHFB.