### PR TITLE
Remove </LI> from the generated HHC and HHK files

### DIFF
--- a/SHFB/Source/SandcastleHtmlExtract/SandcastleHtmlExtract.cs
+++ b/SHFB/Source/SandcastleHtmlExtract/SandcastleHtmlExtract.cs
@@ -824,7 +824,7 @@ commas, or other special characters.
                                         WriteContentLine(writer, indentCount, String.Format(CultureInfo.InvariantCulture,
                                             "    <param name=\"Local\" value=\"{0}\">", WebUtility.HtmlEncode(htmlFile)));
 
-                                    WriteContentLine(writer, indentCount, "  </OBJECT></LI>");
+                                    WriteContentLine(writer, indentCount, "  </OBJECT>");
 
                                     if(reader.IsEmptyElement)
                                         WriteContentLine(writer, indentCount, "</UL>");
@@ -951,7 +951,7 @@ commas, or other special characters.
                 WriteContentLine(writer, indent + 1, String.Format(CultureInfo.InvariantCulture,
                     "<param name=\"Local\" value=\"{0}\">", WebUtility.HtmlEncode(file)));
 
-            WriteContentLine(writer, indent, "</OBJECT></LI>");
+            WriteContentLine(writer, indent, "</OBJECT>");
         }
         #endregion
 


### PR DESCRIPTION
 The DOCTYPE forbids having LI closings. See also the CHM specification on HHC and HHK files: http://www.nongnu.org/chmspec/latest/Sitemap.html ("Note that the tags are mostly in uppercase and the LI tag is not closed; this is in compliance with the doctype.")