### PR TITLE
Small typo in the documentation

### DIFF
--- a/Documentation/SandcastleMAMLGuide/Content/CommonInline/command.aml
+++ b/Documentation/SandcastleMAMLGuide/Content/CommonInline/command.aml
@@ -15,7 +15,7 @@
       <title>Example</title>
       <content>
         <code language="xml" title=" ">
-&lt;command&gt;COPY &lt;system&gt;/s /e&lt;/system&gt;&amp;#160;&lt;replaceable&gt;sourceFileSpec&lt;/replaceable&gt;
+&lt;command&gt;XCOPY &lt;system&gt;/s /e&lt;/system&gt;&amp;#160;&lt;replaceable&gt;sourceFileSpec&lt;/replaceable&gt;
 &amp;#160;&lt;replaceable&gt;destFileSpec&lt;/replaceable&gt;&lt;/command&gt;
 </code>
       </content>


### PR DESCRIPTION
The example used "COPY" instead of "XCOPY".