### PR TITLE
Issue 449 - Fixed search of cyrillic symbols

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
+++ b/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
@@ -503,7 +503,7 @@ function ParseKeywords(keywords)
 {
     var keywordList = [];
     var checkWord;
-    var words = keywords.split(/\s+/);
+    var words = keywords.split(/[\s!@#$%^&*()\-=+\[\]{}\\|<>;:'",.<>/?`~]+/);
 
     for(var idx = 0; idx < words.length; idx++)
     {

--- a/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
+++ b/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
@@ -503,7 +503,7 @@ function ParseKeywords(keywords)
 {
     var keywordList = [];
     var checkWord;
-    var words = keywords.split(/\W+/);
+    var words = keywords.split(/\s+/);
 
     for(var idx = 0; idx < words.length; idx++)
     {


### PR DESCRIPTION
Search did not work with cyrillic words, because regexp \W works with latin only.
This change fixes it.
Issue #449