### PR TITLE
Construct TOC URLs relative to root instead of assuming the target is in the html folder. (#472)

### DIFF
--- a/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
+++ b/SHFB/Source/PresentationStyles/VS2013/Web/scripts/branding-Website.js
@@ -163,8 +163,8 @@ function BuildChildren(tocDiv, data)
         if(childId != null && childId.length > 5)
         {
             // The Url attribute has the form "html/{childId}.htm"
-            childHRef = childId.substring(5, childId.length);
-            childId = childId.substring(5, childId.lastIndexOf("."));
+            childHRef = "../" + childId;
+            childId = childId.substring(childId.lastIndexOf("/") + 1, childId.lastIndexOf("."));
         }
         else
         {

--- a/SHFB/Source/SandcastleBuilderPlugIns/LightweightWebsiteStylePlugIn.cs
+++ b/SHFB/Source/SandcastleBuilderPlugIns/LightweightWebsiteStylePlugIn.cs
@@ -368,7 +368,7 @@ namespace SandcastleBuilder.PlugIns
 
             if(ancestor.Attribute("Url") != null)
             {
-                file = Path.GetFileName(ancestor.Attribute("Url").Value);
+                file = "../" + ancestor.Attribute("Url").Value;
                 tocid = Path.GetFileNameWithoutExtension(file);
             }
             else
@@ -377,7 +377,7 @@ namespace SandcastleBuilder.PlugIns
                 var targetChild = ancestor.Descendants("HelpTOCNode").FirstOrDefault(n => n.Attribute("Url") != null);
 
                 if(targetChild != null)
-                    file = Path.GetFileName(targetChild.Attribute("Url").Value);
+                    file = "../" + ancestor.Attribute("Url").Value;
                 else
                     file = "#!";
 


### PR DESCRIPTION
Fixes #472.