### PR TITLE
Fix bugs found using OpenXML output

### DIFF
--- a/SHFB/Source/PresentationStyles/OpenXml/DocumentParts/word/styles.xml
+++ b/SHFB/Source/PresentationStyles/OpenXml/DocumentParts/word/styles.xml
@@ -952,15 +952,6 @@
 			<w:color w:val="996666"/>
 		</w:rPr>
 	</w:style>
-	<w:style w:type="character" w:customStyle="1" w:styleId="Preprocessor">
-		<w:name w:val="Preprocessor"/>
-		<w:uiPriority w:val="1"/>
-		<w:qFormat/>
-		<w:rsid w:val="00694EC0"/>
-		<w:rPr>
-			<w:color w:val="996666"/>
-		</w:rPr>
-	</w:style>
 	<w:style w:type="character" w:customStyle="1" w:styleId="XmlTag">
 		<w:name w:val="XML Tag"/>
 		<w:uiPriority w:val="1"/>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/CodeTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/CodeTemplates.xsl
@@ -204,7 +204,7 @@
 							</w:tblPr>
 							<w:tr>
 								<w:trPr>
-									<w:cnfStyle w:firstRow="100000000000" />
+									<w:cnfStyle w:val="100000000000" />
 								</w:trPr>
 								<w:tc>
 									<w:p>
@@ -335,7 +335,7 @@
 					</w:tblPr>
 					<w:tr>
 						<w:trPr>
-							<w:cnfStyle w:firstRow="100000000000" />
+							<w:cnfStyle w:val="100000000000" />
 						</w:trPr>
 						<w:tc>
 							<w:p>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/CodeTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/CodeTemplates.xsl
@@ -118,7 +118,7 @@
 			<xsl:if test="(normalize-space(@title) != '') or (not(@title) and normalize-space($p_codeLang) != '' and $p_codeLang != 'other' and $p_codeLang != 'none')">
 				<w:tr>
 					<w:trPr>
-						<w:cnfStyle w:firstRow="1" />
+						<w:cnfStyle w:val="100000000000" />
 					</w:trPr>
 					<w:tc>
 						<w:p>
@@ -204,7 +204,7 @@
 							</w:tblPr>
 							<w:tr>
 								<w:trPr>
-									<w:cnfStyle w:firstRow="1" />
+									<w:cnfStyle w:firstRow="100000000000" />
 								</w:trPr>
 								<w:tc>
 									<w:p>
@@ -335,7 +335,7 @@
 					</w:tblPr>
 					<w:tr>
 						<w:trPr>
-							<w:cnfStyle w:firstRow="1" />
+							<w:cnfStyle w:firstRow="100000000000" />
 						</w:trPr>
 						<w:tc>
 							<w:p>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/GlobalTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/GlobalTemplates.xsl
@@ -364,7 +364,7 @@
 			</w:tblPr>
 			<w:tr>
 				<w:trPr>
-					<w:cnfStyle w:firstRow="1" />
+					<w:cnfStyle w:val="100000000000" />
 				</w:trPr>
 				<w:tc>
 					<w:p>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/HTMLTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/HTMLTemplates.xsl
@@ -207,7 +207,7 @@
 		<w:tr>
 			<xsl:if test="th">
 				<w:trPr>
-					<w:cnfStyle w:firstRow="1" />
+					<w:cnfStyle w:val="100000000000" />
 				</w:trPr>
 			</xsl:if>
 			<xsl:apply-templates/>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/MAMLTemplates.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/MAMLTemplates.xsl
@@ -733,7 +733,7 @@
 	<xsl:template match="ddue:tableHeader/ddue:row" name="t_ddue_tableHeaderRow">
 		<w:tr>
 			<w:trPr>
-				<w:cnfStyle w:firstRow="1" />
+				<w:cnfStyle w:val="100000000000" />
 			</w:trPr>
 			<xsl:apply-templates/>
 		</w:tr>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/MainSandcastle.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/MainSandcastle.xsl
@@ -451,7 +451,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -504,7 +504,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -587,7 +587,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -775,7 +775,7 @@
 			</w:tblPr>
 			<w:tr>
 				<w:trPr>
-					<w:cnfStyle w:firstRow="1" />
+					<w:cnfStyle w:val="100000000000" />
 				</w:trPr>
 				<w:tc>
 					<w:p>

--- a/SHFB/Source/PresentationStyles/OpenXml/Transforms/ReferenceUtilities.xsl
+++ b/SHFB/Source/PresentationStyles/OpenXml/Transforms/ReferenceUtilities.xsl
@@ -552,7 +552,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -632,7 +632,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -689,7 +689,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -827,7 +827,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>
@@ -909,7 +909,7 @@
 			</w:tblPr>
 			<w:tr>
 				<w:trPr>
-					<w:cnfStyle w:firstRow="1" />
+					<w:cnfStyle w:val="100000000000" />
 				</w:trPr>
 				<w:tc>
 					<w:p>
@@ -991,7 +991,7 @@
 						</w:tblPr>
 						<w:tr>
 							<w:trPr>
-								<w:cnfStyle w:firstRow="1" />
+								<w:cnfStyle w:val="100000000000" />
 							</w:trPr>
 							<w:tc>
 								<w:p>

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
@@ -551,7 +551,7 @@ namespace SandcastleBuilder.Utils.MSBuild
         private static void ConvertHtmlLineBreaks(XDocument document)
         {
             foreach(var lineBreak in document.Descendants("br").ToList())
-                lineBreak.ReplaceWith(new XElement(w + "br"));
+                lineBreak.ReplaceWith(new XElement(w + "r", new XElement(w + "br")));
         }
 
         /// <summary>

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
@@ -1228,10 +1228,10 @@ namespace SandcastleBuilder.Utils.MSBuild
                         // we're making an assumption here about the indent widths based on the default style
                         // sheet.
                         props.Add(
-                            new XElement(w + "contextualSpacing",
-                                new XAttribute(w + "val", "0")),
                             new XElement(w + "ind",
-                                new XAttribute(w + "left", ((level + 1) * 720).ToString(CultureInfo.InvariantCulture))));
+                                new XAttribute(w + "left", ((level + 1) * 720).ToString(CultureInfo.InvariantCulture))),
+                            new XElement(w + "contextualSpacing",
+                                new XAttribute(w + "val", "0")));
                     }
                 }
 

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
@@ -690,6 +690,19 @@ namespace SandcastleBuilder.Utils.MSBuild
         }
 
         /// <summary>
+        /// The order in which w:rPr elements should be written.
+        /// </summary>
+        private static readonly string[] runPropsOrder = new[]
+            {
+                "rStyle","rFonts","b","bCs","i","iCs","caps","smallCaps",
+                "strike","dstrike","outline","shadow","emboss","imprint",
+                "noProof","snapToGrid","vanish","webHidden","color","spacing",
+                "w","kern","position","sz","szCs","highlight","u","effect",
+                "bdr","shd","fitText","vertAlign","rtl","cs","em","lang",
+                "eastAsianLayout","specVanish","oMath",
+            };
+
+        /// <summary>
         /// Apply the formatting from a span including all nested spans to each run contained within it
         /// </summary>
         /// <param name="span">The root span from which to start applying formatting</param>
@@ -787,6 +800,9 @@ namespace SandcastleBuilder.Utils.MSBuild
                 span.Value = String.Empty;
                 span.Add(content);
             }
+            
+            // Ensure that the order of rPr children is correct
+            runProps = ReorderChildren(runProps, runPropsOrder);
 
             // Add the run properties to each child run
             foreach(var run in span.Elements(w + "r"))
@@ -805,6 +821,21 @@ namespace SandcastleBuilder.Utils.MSBuild
 
             // And finally, remove the span
             span.Remove();
+        }
+        
+        /// <summary>
+        /// Reorders an elements' children by a specific ordering.
+        /// <summary>
+        /// <param name="element">Element whose children should be in a specific order</param>
+        /// <param name="orderings">The specific order of child element, by local name</param>
+        /// <returns><paramref name="element" /> with its children reordered.</returns>
+        private static XElement ReorderChildren(XElement element, IList<string> orderings)
+        {
+            var orderedChildren = element.Elements()
+                                         .OrderBy(e => orderings.IndexOf(e.Name.LocalName))
+                                         .ToArray();
+            element.ReplaceNodes(orderedChildren);
+            return element;
         }
         #endregion
 

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
@@ -1077,6 +1077,12 @@ namespace SandcastleBuilder.Utils.MSBuild
                         new XAttribute("distL", "0"), new XAttribute("distR", "0"),
                             extent, docPr, cNvGraphicFramePr, graphic));
 
+                // Ensure the <w:drawing> is within a <w:r> and not a bare <w:p>
+                if (image.Parent.Name != w + "r")
+                {
+                    drawing = new XElement(w + "r", drawing);
+                }
+                
                 image.ReplaceWith(drawing);
                 imageId++;
             }

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuild/BuildOpenXmlFile.cs
@@ -604,7 +604,7 @@ namespace SandcastleBuilder.Utils.MSBuild
                         Enumerable.Range(0, cellCount).Select(_ => new XElement(w + "gridCol")));
                     
                     // then put the <w:tblGrid> element just before the first <w:tr>
-                    table.Elements(w + "tr").First().AddBeforeSelf(tblGrid);
+                    table.Element(w + "tr").AddBeforeSelf(tblGrid);
                 }
                 
                 // Check if this table needs to be "unwrapped" from a parent <w:p>


### PR DESCRIPTION
We're migrating our HTML Help to OpenXML and found a few issues with the output. I used Open XML SDK's OpenXmlValidator to identify these issues and work on the corrections. I've not tried these corrections as part of the MSBuild task (yet), but have done so individually. Most of these seem like issues with the version of the Open XML used in SHFB, and fall into three main categories:
1. Elements are out of order per the XSD sequence.
2. Elements are not within the correct parent element.
3. Elements and/or attributes need to be updated to the correct version.

This addresses #667.