### PR TITLE
Update BE0037.aml

### DIFF
--- a/Documentation/SandcastleBuilder/Content/ErrorsAndWarnings/BuildEngine/BE0037.aml
+++ b/Documentation/SandcastleBuilder/Content/ErrorsAndWarnings/BuildEngine/BE0037.aml
@@ -2,7 +2,7 @@
 <topic id="e2af12c6-af9e-4b59-9fe1-fc3c413022ae" revisionNumber="1">
   <developerConceptualDocument xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5" xmlns:xlink="http://www.w3.org/1999/xlink">
     <introduction>
-      <para>Error BE0037: Could not find the path to the HTML Help 1 compiler.</para>
+      <para>Error BE0037: Could not find the path to the HTML Help 1 compiler</para>
     </introduction>
 
     <section>

--- a/Documentation/SandcastleBuilder/Content/ErrorsAndWarnings/BuildEngine/BE0037.aml
+++ b/Documentation/SandcastleBuilder/Content/ErrorsAndWarnings/BuildEngine/BE0037.aml
@@ -2,7 +2,7 @@
 <topic id="e2af12c6-af9e-4b59-9fe1-fc3c413022ae" revisionNumber="1">
   <developerConceptualDocument xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5" xmlns:xlink="http://www.w3.org/1999/xlink">
     <introduction>
-      <para>Error BE0037: Could not find the path to the HTML Help 1 compiler</para>
+      <para>Error BE0037: Could not find the path to the HTML Help 1 compiler.</para>
     </introduction>
 
     <section>
@@ -22,7 +22,7 @@ any fixed drive.</para>
 <list class="bullet">
   <listItem>Review the <link xlink:href="8c0c97d0-c968-4c15-9fe9-e8f3a443c50a" />
 carefully and make sure that you have installed all of the required tools and
-have the latest version of each.</listItem>
+have the latest version of each. It could be that the 'HTML Help Workshop' is not installed, which can be installed from here: https://docs.microsoft.com/previous-versions/windows/desktop/htmlhelp/microsoft-html-help-downloads</listItem>
 
   <listItem>If all else fails, manually specify the location of the HTML Help
 1 compiler by entering the path in the <codeInline>HtmlHelp1xCompilerPath</codeInline>


### PR DESCRIPTION
Add more detailed info how to install required HTML Help Workshop that is probably the problem as recent Azure images do not include this tool any more
I ended up spending a few hours trying to install Visual Studio workloads on a new server as I though the .Net pre-requisites were not met and the error message/documentation was not guiding me enough.
I am happy to work more on the appropriate text or how you'd like to manage links, this PR is just to start the conversation. Would it be possible to add a similar change to the actual error message? Is there a way that the Nuget packages can ship a self-contained version of this legacy dependency?