### PR TITLE
Nuget package improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ _ReSharper*/
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/NuGet/SHFB.NETCore.nuspec
+++ b/NuGet/SHFB.NETCore.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\.NETCore\*.*" target="tools\Data\.NETCore" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.NETCore.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.NETFramework.nuspec
+++ b/NuGet/SHFB.NETFramework.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\.NETFramework\*.*" target="tools\Data\.NETFramework" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.NETFramework.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.NETMicroFramework.nuspec
+++ b/NuGet/SHFB.NETMicroFramework.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\.NETMicroFramework\*.*" target="tools\Data\.NETMicroFramework" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.NETMicroFramework.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.NETPortable.nuspec
+++ b/NuGet/SHFB.NETPortable.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\.NETPortable\*.*" target="tools\Data\.NETPortable" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.NETPortable.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.Silverlight.nuspec
+++ b/NuGet/SHFB.Silverlight.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\Silverlight\*.*" target="tools\Data\Silverlight" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.Silverlight.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.UniversalWindows.nuspec
+++ b/NuGet/SHFB.UniversalWindows.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\UniversalWindows\*.*" target="tools\Data\UniversalWindows" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.UniversalWindows.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.WindowsPhone.nuspec
+++ b/NuGet/SHFB.WindowsPhone.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\WindowsPhone\*.*" target="tools\Data\WindowsPhone" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.WindowsPhone.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.WindowsPhoneApp.nuspec
+++ b/NuGet/SHFB.WindowsPhoneApp.nuspec
@@ -19,5 +19,6 @@
 	</metadata>
 	<files>
 		<file src="..\SHFB\Deploy\Data\WindowsPhoneApp\*.*" target="tools\Data\WindowsPhoneApp" />
+		<file src="build\EWSoftware.SHFB.ReflectionData.props" target="build\EWSoftware.SHFB.WindowsPhoneApp.props" />
 	</files>
 </package>

--- a/NuGet/SHFB.nuspec
+++ b/NuGet/SHFB.nuspec
@@ -27,5 +27,6 @@
 		<file src="&deploy;\Templates\**\*.*" target="tools\Templates" exclude="&commonExcludes;" />
 		<file src="&deploy;\*.*" target="tools" exclude="&deploy;\ICSharpCode*;&deploy;\SandcastleBuilderGUI*;&deploy;\WeifenLuo*;&deploy;\ReflectionDataManager*.*;&deploy;\BuildComponents.xml;&deploy;\ColorizerLibrary.xml;&deploy;\Sandcastle*.xml;&deploy;\SyntaxComponents.xml;&deploy;\*Hunspell*;&deploy;\SHFBProjectLauncher*;&deploy;\ESent*.xml;&deploy;\GenerateInheritedDocs.xml;&deploy;\HelpLibraryManagerLauncher.xml;&deploy;\NHunSpell.xml;&deploy;\SandcastleBuilderGUI.xml;&deploy;\SandcastleHtmlExtract.xml;&deploy;\AddNamespaceGroups.xml;&deploy;\SegregateByNamespace.xml;&deploy;\XslTransform.xml;&deploy;\reflection.org;&commonExcludes;" />
 		<file src="ReadMe.txt" target="ReadMe.txt" />
+		<file src="build\EWSoftware.SHFB.props" target="build" />
 	</files>
 </package>

--- a/NuGet/build/EWSoftware.SHFB.ReflectionData.props
+++ b/NuGet/build/EWSoftware.SHFB.ReflectionData.props
@@ -1,0 +1,5 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ComponentPath Condition="$(ComponentPath) == ''">$(MSBuildThisFileDirectory)..\Tools\</ComponentPath>
+  </PropertyGroup>
+</Project>

--- a/NuGet/build/EWSoftware.SHFB.props
+++ b/NuGet/build/EWSoftware.SHFB.props
@@ -1,0 +1,5 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SHFBROOT Condition="$(SHFBROOT ) == ''">$(MSBuildThisFileDirectory)..\Tools\</SHFBROOT >
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Include a .props file in each package that defaults the `SHFBROOT` and `ComponentPath` properties to the package location.

Advantages:
- Using nuget packages now runs out of the box - no need to figure out paths and fiddling with configuration of the project
- Instant support for `PackageReference`, to be compatible with the latest Nuget features

With this you only need to add two package references to your .shfbproj to make it work:
```xml
<ItemGroup>
  <PackageReference Include="EWSoftware.SHFB" Version="2019.4.14" />
  <PackageReference Include="EWSoftware.SHFB.NETFramework" Version="4.7.2" />
</ItemGroup>
```

It's fully backward compatible since you can just overwrite the properties in your project. 