### PR TITLE
Added dotnet core implementation for Core and Utils projects

### DIFF
--- a/SHFB/Source/Sandcastle-DotNetCore.sln
+++ b/SHFB/Source/Sandcastle-DotNetCore.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandcastle.Core-DotNetCore", "SandcastleCore\Sandcastle.Core-DotNetCore.csproj", "{F0DF7031-B260-4AEC-B231-91DD09104F60}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SandcastleBuilder.Utils-DotNetCore", "SandcastleBuilderUtils\SandcastleBuilder.Utils-DotNetCore.csproj", "{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F0DF7031-B260-4AEC-B231-91DD09104F60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0DF7031-B260-4AEC-B231-91DD09104F60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0DF7031-B260-4AEC-B231-91DD09104F60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0DF7031-B260-4AEC-B231-91DD09104F60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E4F9B709-941B-47F7-A5BE-F4E7B7303417}
+	EndGlobalSection
+EndGlobal

--- a/SHFB/Source/Sandcastle-DotNetCore.sln
+++ b/SHFB/Source/Sandcastle-DotNetCore.sln
@@ -4,8 +4,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandcastle.Core-DotNetCore", "SandcastleCore\Sandcastle.Core-DotNetCore.csproj", "{F0DF7031-B260-4AEC-B231-91DD09104F60}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9C628CB8-908A-4B18-B746-01677EB73BF4} = {9C628CB8-908A-4B18-B746-01677EB73BF4}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SandcastleBuilder.Utils-DotNetCore", "SandcastleBuilderUtils\SandcastleBuilder.Utils-DotNetCore.csproj", "{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9C628CB8-908A-4B18-B746-01677EB73BF4} = {9C628CB8-908A-4B18-B746-01677EB73BF4}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuildAssemblyLoader", "SandcastleBuilderUtils\MSBuildAssemblyLoader\MSBuildAssemblyLoader.csproj", "{9C628CB8-908A-4B18-B746-01677EB73BF4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +29,10 @@ Global
 		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79E4F443-FAA1-4007-A8C8-3E9B2A5AB0AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C628CB8-908A-4B18-B746-01677EB73BF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C628CB8-908A-4B18-B746-01677EB73BF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C628CB8-908A-4B18-B746-01677EB73BF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C628CB8-908A-4B18-B746-01677EB73BF4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SHFB/Source/SandcastleBuilderUtils/BuildEngine/JavaScriptSerializer.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/BuildEngine/JavaScriptSerializer.cs
@@ -6,8 +6,7 @@
 // Note    : Copyright 2007-2020, Eric Woodruff, All rights reserved
 // Compiler: Microsoft Visual C#
 //
-// This file contains a class used to create a full-text index used to search for topics in the ASP.NET web
-// pages.  It's a really basic implementation but should get the job done.
+// This file Provides proxy serialization and deserialization functionality.
 //
 // Design Decision:
 //    This class does not exist in .NET core, so this just proxies functionality to Newtonsoft.Json. If the

--- a/SHFB/Source/SandcastleBuilderUtils/BuildEngine/JavaScriptSerializer.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/BuildEngine/JavaScriptSerializer.cs
@@ -1,0 +1,53 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Help File Builder Utilities
+// File    : JavaScriptSerializer.cs
+// Author  : J. Ritchie Carroll  (rcarroll@gmail.com)
+// Updated : 02/05/2016
+// Note    : Copyright 2007-2020, Eric Woodruff, All rights reserved
+// Compiler: Microsoft Visual C#
+//
+// This file contains a class used to create a full-text index used to search for topics in the ASP.NET web
+// pages.  It's a really basic implementation but should get the job done.
+//
+// Design Decision:
+//    This class does not exist in .NET core, so this just proxies functionality to Newtonsoft.Json. If the
+//    JsonConvert function works well then original code can drop usages of the JavaScriptSerializer and delete
+//    this class.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 01/15/2020  JRC  Created the code
+//
+//===============================================================================================================
+
+using Newtonsoft.Json;
+
+namespace System.Web.Script.Serialization
+{
+    /// <summary>
+    /// Provides proxy serialization and deserialization functionality.
+    /// </summary>
+    public class JavaScriptSerializer
+    {
+        /// <summary>
+        /// Gets or sets the maximum length of JSON strings that are accepted by the <see cref="JavaScriptSerializer"/> class.
+        /// </summary>
+        public Int32 MaxJsonLength { get; set; } = Int32.MaxValue;
+
+        /// <summary>
+        /// Converts an object to a JSON string.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>The serialized JSON string.</returns>
+        public string Serialize (object obj)
+        {
+            string result = JsonConvert.SerializeObject(obj);
+            return result.Length > this.MaxJsonLength ? result.Substring(0, this.MaxJsonLength) : result;
+        }
+    }
+}

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuildAssemblyLoader/LoadAssemblies.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuildAssemblyLoader/LoadAssemblies.cs
@@ -1,0 +1,59 @@
+﻿//=============================================================================
+// System  : Sandcastle Help File Builder MSBuild Tasks
+// File    : LoadAssemblies.cs
+// Author  : J. Ritchie Carroll (ritchiecarroll@gmail.com)
+// Updated : 01/06/2020
+// Note    : Copyright 2008-2011, Eric Woodruff, All rights reserved
+// Compiler: Microsoft Visual C#
+//
+// Pre-loads all MSBuild task assemblies in current folder
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy
+// of the license should be distributed with the code.  It can also be found
+// at the project website: https://GitHub.com/EWSoftware/SHFB.   This notice, the
+// author's name, and all copyright notices must remain intact in all
+// applications, documentation, and source files.
+//
+// Version     Date     Who  Comments
+// ============================================================================
+// 1.0.0.0  01/16/2020  JRC  Created the code
+// ============================================================================
+
+using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace MSBuildAssemblyLoader
+{
+    /// <summary>
+    /// Task to attempt pre-load of MSBuild assemblies.
+    /// </summary>
+    public class LoadAssemblies : Task
+    {
+        /// <summary>Must be implemented by derived class.</summary>
+        /// <returns>true, if successful</returns>
+        public override bool Execute()
+        {
+            string location = Path.GetDirectoryName(typeof(LoadAssemblies).Assembly.Location);
+            string[] assemblies = Directory.GetFiles(location, "*.dll");
+
+            foreach(string assembly in assemblies)
+            {
+                try
+                {
+                    Log.LogMessage(MessageImportance.Normal, $"Attempting to load \"{assembly}\"...");
+                    Assembly.LoadFrom(assembly);
+                    Log.LogMessage(MessageImportance.Normal, "Load success.");
+                }
+                catch(Exception ex)
+                {
+                    Log.LogMessage(MessageImportance.Normal, $"Load failed: {ex.Message}");
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/SHFB/Source/SandcastleBuilderUtils/MSBuildAssemblyLoader/MSBuildAssemblyLoader.csproj
+++ b/SHFB/Source/SandcastleBuilderUtils/MSBuildAssemblyLoader/MSBuildAssemblyLoader.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <RootNamespace>Sandcastle.Core</RootNamespace>
-    <PackageId>Sandcastle.Core</PackageId>
+    <RootNamespace>MSBuildAssemblyLoader</RootNamespace>
+    <PackageId>MSBuildAssemblyLoader</PackageId>
     <Authors>Eric Woodruff</Authors>
     <Company>Eric Woodruff</Company>
     <Product>Sandcastle</Product>
@@ -24,31 +24,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Sandcastle.Core</AssemblyName>
-    <OutputPath>bin\$(Configuration)</OutputPath>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\Sandcastle.Core.xml</DocumentationFile>
-    <DefineConstants>DOTNETCORE</DefineConstants>
+    <AssemblyName>MSBuildAssemblyLoader</AssemblyName>
+    <OutputPath>..\bin\$(Configuration)</OutputPath>
+    <DocumentationFile>$(OutputPath)\$(TargetFramework)\MSBuildAssemblyLoader.xml</DocumentationFile>
   </PropertyGroup>
-
-  <!-- Exclude unused / unavailable code items -->
-  <ItemGroup>
-    <EmbeddedResource Remove="Properties\**" />
-    <EmbeddedResource Remove="Resources\**" />
-    <Compile Remove="Properties\**" />
-    <Compile Remove="Resources\**" />
-    <Compile Remove="BuildAssembler\BuildComponent\ConfigurationEditorDlg.xaml.cs" />
-    <Compile Remove="WpfHelpers.cs" />
-    <None Remove="Properties\**" />
-    <None Remove="Resources\**" />
-    <None Remove="BuildAssembler\BuildComponent\ConfigurationEditorDlg.xaml" />
-    <None Remove="packages.config" />
-  </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.4.0" />
   </ItemGroup>
 
 </Project>

--- a/SHFB/Source/SandcastleBuilderUtils/ProxyClasses.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/ProxyClasses.cs
@@ -33,12 +33,18 @@ namespace SandcastleBuilder.Utils.Design
 
     [CompilerGenerated]
     internal class FilePathTypeConverter { }
+    
+    [CompilerGenerated]
+    internal class FilePathStringEditor { }
 
     [CompilerGenerated]
     internal class FolderPathObjectEditor { }
 
     [CompilerGenerated]
     internal class FolderPathTypeConverter { }
+    
+    [CompilerGenerated]
+    internal class FolderPathStringEditor { }
 }
 
 namespace System.Drawing.Design

--- a/SHFB/Source/SandcastleBuilderUtils/ProxyClasses.cs
+++ b/SHFB/Source/SandcastleBuilderUtils/ProxyClasses.cs
@@ -1,0 +1,150 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Help File Builder Utilities
+// File    : JavaScriptSerializer.cs
+// Author  : J. Ritchie Carroll  (rcarroll@gmail.com)
+// Updated : 02/05/2016
+// Note    : Copyright 2007-2020, Eric Woodruff, All rights reserved
+// Compiler: Microsoft Visual C#
+//
+// These namespaces and classes only exist to satisfy compiler from within a .NET core compilation.
+//
+// Design Decision:
+//    These classes do not not exist in .NET core, so this just adds the types to make project compile.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 01/15/2020  JRC  Created the code
+//
+//===============================================================================================================
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace SandcastleBuilder.Utils.Design
+{
+    [CompilerGenerated]
+    internal class FilePathObjectEditor { }
+
+    [CompilerGenerated]
+    internal class FilePathTypeConverter { }
+
+    [CompilerGenerated]
+    internal class FolderPathObjectEditor { }
+
+    [CompilerGenerated]
+    internal class FolderPathTypeConverter { }
+}
+
+namespace System.Drawing.Design
+{
+    [CompilerGenerated]
+    internal class UITypeEditor { }
+}
+
+namespace System.Windows.Forms
+{
+    [CompilerGenerated]
+    internal enum MessageBoxButtons
+    {
+        OK,
+        OKCancel,
+        AbortRetryIgnore,
+        YesNoCancel,
+        YesNo,
+        RetryCancel
+    }
+
+    [CompilerGenerated]
+    internal enum MessageBoxIcon
+    {
+        None,
+        Hand,
+        Question,
+        Exclamation,
+        Asterisk,
+        Stop,
+        Erro,
+        Warning,
+        Information
+    }
+
+    [CompilerGenerated]
+    internal static class MessageBox
+    {
+        public static void Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
+        {
+            Console.WriteLine($"[{caption}: {text}");
+        }
+    }
+}
+
+namespace Microsoft.Build.BuildEngine
+{
+    // This code derived from MIT licensed source:
+    // https://github.com/microsoft/msbuild/blob/master/src/Shared/EscapingUtilities.cs
+    [CompilerGenerated]
+    internal static class Utilities
+    {
+        public static string Escape(string value)
+        {
+            if (String.IsNullOrEmpty(value) || !ContainsReservedCharacters(value))
+                return value;
+
+            StringBuilder escapedStringBuilder = new StringBuilder();
+            AppendEscapedString(escapedStringBuilder, value);
+            return escapedStringBuilder.ToString();
+        }
+
+        private static bool IsHexDigit(char character)
+        {
+            return character >= '0' && character <= '9'
+                || character >= 'A' && character <= 'F'
+                || character >= 'a' && character <= 'f';
+        }
+
+        private static bool ContainsReservedCharacters(string unescapedString)
+        {
+            return -1 != unescapedString.IndexOfAny(s_charsToEscape);
+        }
+
+        private static char HexDigitChar(int x)
+        {
+            return (char)(x + (x < 10 ? '0' : 'a' - 10));
+        }
+
+        private static void AppendEscapedChar(StringBuilder sb, char ch)
+        {
+            // Append the escaped version which is a percent sign followed by two hexadecimal digits
+            sb.Append('%');
+            sb.Append(HexDigitChar(ch / 0x10));
+            sb.Append(HexDigitChar(ch & 0x0F));
+        }
+
+        private static void AppendEscapedString(StringBuilder sb, string unescapedString)
+        {
+            // Replace each unescaped special character with an escape sequence one
+            for (int idx = 0; ;)
+            {
+                int nextIdx = unescapedString.IndexOfAny(s_charsToEscape, idx);
+
+                if(nextIdx == -1)
+                {
+                    sb.Append(unescapedString, idx, unescapedString.Length - idx);
+                    break;
+                }
+
+                sb.Append(unescapedString, idx, nextIdx - idx);
+                AppendEscapedChar(sb, unescapedString[nextIdx]);
+                idx = nextIdx + 1;
+            }
+        }
+
+        private static readonly char[] s_charsToEscape = { '%', '*', '?', '@', '$', '(', ')', ';', '\'' };
+    }
+}

--- a/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>SandcastleBuilder.Utils</RootNamespace>
     <PackageId>SandcastleBuilder.Utils</PackageId>
     <Authors>Eric Woodruff</Authors>
@@ -13,10 +13,8 @@
     <PackageProjectUrl>https://github.com/EWSoftware/SHFB</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EWSoftware/SHFB</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <PackageTags>Sandcastle;Help;Builder;Utilities</PackageTags>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Version>19.11.17</Version>
     <InformationalVersion Condition="'$(Configuration)'=='Release'">Release Build</InformationalVersion>

--- a/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
@@ -1,0 +1,78 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>SandcastleBuilder.Utils</RootNamespace>
+    <PackageId>SandcastleBuilder.Utils</PackageId>
+    <Authors>Eric Woodruff</Authors>
+    <Company>Eric Woodruff</Company>
+    <Product>Sandcastle</Product>
+    <PackageDescription>Sandcastle Help File Builder and Tools</PackageDescription>
+    <Description>This assembly contains the project, build engine, and Managed Extensibility Framework (MEF) classes used by all of the other Sandcastle Help File Builder applications.</Description>
+    <Copyright>Copyright © 2006-2020, Eric Woodruff, All Rights Reserved</Copyright>
+    <PackageProjectUrl>https://github.com/EWSoftware/SHFB</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/EWSoftware/SHFB</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
+    <PackageTags>Sandcastle;Help;Builder;Utilities</PackageTags>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Version>19.11.17</Version>
+    <InformationalVersion Condition="'$(Configuration)'=='Release'">Release Build</InformationalVersion>
+    <InformationalVersion Condition="'$(Configuration)'!='Release'">Debug Build</InformationalVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyName>Sandcastle.Utils</AssemblyName>
+    <OutputPath>bin\$(Configuration)</OutputPath>
+    <DocumentationFile>$(OutputPath)\Sandcastle.Utils.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcore'))">
+    <DefineConstants>DOTNETCORE</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Exclude unused / unavailable code items -->
+  <ItemGroup>
+    <Compile Remove="Controls\**" />
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+    <Compile Remove="Properties\AssemblyInfoShared.cs" />
+    <Compile Remove="Design\FilePathObjectEditor.cs" />
+    <Compile Remove="Design\FilePathStringEditor.cs" />
+    <Compile Remove="Design\FilePathTypeConverter.cs" />
+    <Compile Remove="Design\FolderPathObjectEditor.cs" />
+    <Compile Remove="Design\FolderPathStringEditor.cs" />
+    <Compile Remove="Design\FolderPathTypeConverter.cs" />
+    <EmbeddedResource Remove="Controls\**" />
+    <None Remove="Controls\**" />
+    <None Remove="packages.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NoneInvisible Include="@(None-&gt;WithMetadataValue('Visible', 'false'))" />
+    <None Remove="@(NoneInvisible)" />
+  </ItemGroup>
+
+  <Target Name="IncludeNoneInvisible" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <None Include="@(NoneInvisible)" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="DotNetZip" Version="1.13.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SandcastleCore\Sandcastle.Core-DotNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Library</OutputType>
     <RootNamespace>SandcastleBuilder.Utils</RootNamespace>
     <PackageId>SandcastleBuilder.Utils</PackageId>
     <Authors>Eric Woodruff</Authors>
@@ -19,21 +20,21 @@
     <Version>19.11.17</Version>
     <InformationalVersion Condition="'$(Configuration)'=='Release'">Release Build</InformationalVersion>
     <InformationalVersion Condition="'$(Configuration)'!='Release'">Debug Build</InformationalVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>SandcastleBuilder.Utils</AssemblyName>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\SandcastleBuilder.Utils.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcore'))">
     <DefineConstants>DOTNETCORE</DefineConstants>
   </PropertyGroup>
+  
 
   <!-- Exclude unused / unavailable code items -->
   <ItemGroup>
     <Compile Remove="Controls\**" />
+    <Compile Remove="MSBuildAssemblyLoader\**" />
     <Compile Remove="Properties\AssemblyInfo.cs" />
     <Compile Remove="Properties\AssemblyInfoShared.cs" />
     <Compile Remove="Design\FilePathObjectEditor.cs" />
@@ -43,20 +44,11 @@
     <Compile Remove="Design\FolderPathStringEditor.cs" />
     <Compile Remove="Design\FolderPathTypeConverter.cs" />
     <EmbeddedResource Remove="Controls\**" />
+    <EmbeddedResource Remove="MSBuildAssemblyLoader\**" />
     <None Remove="Controls\**" />
+    <None Remove="MSBuildAssemblyLoader\**" />
     <None Remove="packages.config" />
   </ItemGroup>
-
-  <ItemGroup>
-    <NoneInvisible Include="@(None-&gt;WithMetadataValue('Visible', 'false'))" />
-    <None Remove="@(NoneInvisible)" />
-  </ItemGroup>
-
-  <Target Name="IncludeNoneInvisible" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <None Include="@(NoneInvisible)" />
-    </ItemGroup>
-  </Target>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.4.0" />
@@ -65,6 +57,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.4.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     <PackageReference Include="DotNetZip" Version="1.13.4" />
   </ItemGroup>

--- a/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleBuilderUtils/SandcastleBuilder.Utils-DotNetCore.csproj
@@ -22,9 +22,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Sandcastle.Utils</AssemblyName>
+    <AssemblyName>SandcastleBuilder.Utils</AssemblyName>
     <OutputPath>bin\$(Configuration)</OutputPath>
-    <DocumentationFile>$(OutputPath)\Sandcastle.Utils.xml</DocumentationFile>
+    <DocumentationFile>$(OutputPath)\$(TargetFramework)\SandcastleBuilder.Utils.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netcore'))">

--- a/SHFB/Source/SandcastleBuilderUtils/SandcastleHelpFileBuilder.targets
+++ b/SHFB/Source/SandcastleBuilderUtils/SandcastleHelpFileBuilder.targets
@@ -1,110 +1,114 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<!-- Sandcastle Help File Builder Tasks.  https://GitHub.com/EWSoftware/SHFB -->
-	<UsingTask TaskName="SandcastleBuilder.Utils.MSBuild.BuildHelp"
-    AssemblyFile="$(SHFBROOT)\SandcastleBuilder.Utils.dll" />
-	<UsingTask TaskName="SandcastleBuilder.Utils.MSBuild.CleanHelp"
-    AssemblyFile="$(SHFBROOT)\SandcastleBuilder.Utils.dll" />
+<Project DefaultTargets="Build" TreatAsLocalProperty="TaskAssembly" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<!-- Define OutDir if not set already so that it doesn't pick up our project OutputPath setting
+  <!-- Sandcastle Help File Builder Tasks.  https://GitHub.com/EWSoftware/SHFB -->
+  <PropertyGroup>
+    <TaskAssembly Condition=" '$(MSBuildRuntimeType)'!='Core'">$(SHFBROOT)\SandcastleBuilder.Utils.dll</TaskAssembly>
+    <TaskAssembly Condition=" '$(MSBuildRuntimeType)'=='Core'">$(SHFBROOT)\DotNetCore\SandcastleBuilder.Utils.dll</TaskAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="SandcastleBuilder.Utils.MSBuild.BuildHelp" AssemblyFile="$(TaskAssembly)" />
+  <UsingTask TaskName="SandcastleBuilder.Utils.MSBuild.CleanHelp" AssemblyFile="$(TaskAssembly)" />
+
+  <!-- Define OutDir if not set already so that it doesn't pick up our project OutputPath setting
        when the common targets are imported below. -->
-	<PropertyGroup>
-		<OutDir Condition=" '$(OutDir)' == '' ">.\</OutDir>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutDir Condition=" '$(OutDir)' == '' ">.\</OutDir>
+  </PropertyGroup>
 
-	<!-- Include common targets to allow use in the VSPackage within Visual Studio -->
-	<Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  <!-- Include common targets to allow use in the VSPackage within Visual Studio -->
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
 
-	<!-- Override this target to removed it.  Visual Studio tries to run it under certain conditions but
+  <!-- Override this target to removed it.  Visual Studio tries to run it under certain conditions but
        we don't contain one of its dependent targets and we don't need this one anyway as far as I
        can tell. -->
-	<Target Name="AllProjectOutputGroups" />
+  <Target Name="AllProjectOutputGroups" />
 
-	<!-- Include custom before target overrides if specified -->
-	<Import Project="$(CustomBeforeSHFBTargets)" Condition="Exists('$(CustomBeforeSHFBTargets)')" />
+  <!-- Include custom before target overrides if specified -->
+  <Import Project="$(CustomBeforeSHFBTargets)" Condition="Exists('$(CustomBeforeSHFBTargets)')" />
 
-	<!-- This defines the dependencies for the Build target -->
-	<PropertyGroup>
-		<BuildDependsOn>
-			PreBuildEvent;
-			BeforeBuildHelp;
-			CoreBuildHelp;
-			AfterBuildHelp;
-			PostBuildEvent
-		</BuildDependsOn>
-	</PropertyGroup>
+  <!-- This defines the dependencies for the Build target -->
+  <PropertyGroup>
+    <BuildDependsOn>
+      PreBuildEvent;
+      BeforeBuildHelp;
+      CoreBuildHelp;
+      AfterBuildHelp;
+      PostBuildEvent
+    </BuildDependsOn>
+  </PropertyGroup>
 
-	<Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
 
-	<!-- The Core Build Help target -->
-	<Target Name="CoreBuildHelp">
-		<SandcastleBuilder.Utils.MSBuild.BuildHelp
+  <!-- The Core Build Help target -->
+  <Target Name="CoreBuildHelp">
+    <SandcastleBuilder.Utils.MSBuild.BuildHelp
         ProjectFile="$(MSBuildProjectFullPath)"
-				Configuration="$(Configuration)"
-				Platform="$(Platform)"
+        Configuration="$(Configuration)"
+        Platform="$(Platform)"
         Properties="$(SubstitutionTags)"
-				OutDir="$(OutDir)"
-				Verbose="$(Verbose)"
-				DumpLogOnFailure="$(DumpLogOnFailure)"
-				AlwaysLoadProject="$(AlwaysLoadProject)">
-			<Output TaskParameter="Help1Files" ItemName="Help1Files" />
-			<Output TaskParameter="HelpViewerFiles" ItemName="HelpViewerFiles" />
-			<Output TaskParameter="WebsiteFiles" ItemName="WebsiteFiles" />
-			<Output TaskParameter="OpenXmlFiles" ItemName="OpenXmlFiles" />
-			<Output TaskParameter="MarkdownFiles" ItemName="MarkdownFiles" />
-			<Output TaskParameter="AllHelpFiles" ItemName="AllHelpFiles" />
-		</SandcastleBuilder.Utils.MSBuild.BuildHelp>
+        OutDir="$(OutDir)"
+        Verbose="$(Verbose)"
+        DumpLogOnFailure="$(DumpLogOnFailure)"
+        AlwaysLoadProject="$(AlwaysLoadProject)">
+      <Output TaskParameter="Help1Files" ItemName="Help1Files" />
+      <Output TaskParameter="HelpViewerFiles" ItemName="HelpViewerFiles" />
+      <Output TaskParameter="WebsiteFiles" ItemName="WebsiteFiles" />
+      <Output TaskParameter="OpenXmlFiles" ItemName="OpenXmlFiles" />
+      <Output TaskParameter="MarkdownFiles" ItemName="MarkdownFiles" />
+      <Output TaskParameter="AllHelpFiles" ItemName="AllHelpFiles" />
+    </SandcastleBuilder.Utils.MSBuild.BuildHelp>
 
-		<OnError ExecuteTargets="PostBuildEvent" Condition="'$(RunPostBuildEvent)'=='Always'"/>
-	</Target>
+    <OnError ExecuteTargets="PostBuildEvent" Condition="'$(RunPostBuildEvent)'=='Always'"/>
+  </Target>
 
-	<!-- The following targets may be overridden in project files to perform
+  <!-- The following targets may be overridden in project files to perform
        additional processing. -->
-	<Target Name="BeforeBuildHelp" />
-	<Target Name="AfterBuildHelp" />
+  <Target Name="BeforeBuildHelp" />
+  <Target Name="AfterBuildHelp" />
 
-	<!-- This defines the dependencies for the Clean target -->
-	<PropertyGroup>
-		<CleanDependsOn>
-			BeforeCleanHelp;
-			CoreCleanHelp;
-			AfterCleanHelp
-		</CleanDependsOn>
-	</PropertyGroup>
+  <!-- This defines the dependencies for the Clean target -->
+  <PropertyGroup>
+    <CleanDependsOn>
+      BeforeCleanHelp;
+      CoreCleanHelp;
+      AfterCleanHelp
+    </CleanDependsOn>
+  </PropertyGroup>
 
-	<Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
+  <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
 
-	<!-- The Core Clean Help target -->
-	<Target Name="CoreCleanHelp">
-		<SandcastleBuilder.Utils.MSBuild.CleanHelp
+  <!-- The Core Clean Help target -->
+  <Target Name="CoreCleanHelp">
+    <SandcastleBuilder.Utils.MSBuild.CleanHelp
         ProjectFile="$(MSBuildProjectFullPath)"
         OutputPath="$(OutputPath)"
         WorkingPath="$(WorkingPath)"
         LogFileLocation="$(LogFileLocation)" />
-	</Target>
+  </Target>
 
-	<!-- The following targets may be overridden in project files to perform
+  <!-- The following targets may be overridden in project files to perform
        additional processing. -->
-	<Target Name="BeforeCleanHelp" />
-	<Target Name="AfterCleanHelp" />
+  <Target Name="BeforeCleanHelp" />
+  <Target Name="AfterCleanHelp" />
 
-	<!-- This defines the dependencies for the Rebuild target -->
-	<PropertyGroup>
-		<RebuildDependsOn>
-			BeforeRebuildHelp;
-			Clean;
-			Build;
-			AfterRebuildHelp;
-		</RebuildDependsOn>
-	</PropertyGroup>
+  <!-- This defines the dependencies for the Rebuild target -->
+  <PropertyGroup>
+    <RebuildDependsOn>
+      BeforeRebuildHelp;
+      Clean;
+      Build;
+      AfterRebuildHelp;
+    </RebuildDependsOn>
+  </PropertyGroup>
 
-	<Target Name="Rebuild" DependsOnTargets="$(RebuildDependsOn)" />
+  <Target Name="Rebuild" DependsOnTargets="$(RebuildDependsOn)" />
 
-	<!-- The following targets may be overridden in project files to perform
+  <!-- The following targets may be overridden in project files to perform
        additional processing. -->
-	<Target Name="BeforeRebuildHelp" />
-	<Target Name="AfterRebuildHelp" />
+  <Target Name="BeforeRebuildHelp" />
+  <Target Name="AfterRebuildHelp" />
 
-	<!-- Include custom after target overrides if specified -->
-	<Import Project="$(CustomAfterSHFBTargets)" Condition="Exists('$(CustomAfterSHFBTargets)')" />
+  <!-- Include custom after target overrides if specified -->
+  <Import Project="$(CustomAfterSHFBTargets)" Condition="Exists('$(CustomAfterSHFBTargets)')" />
 
 </Project>

--- a/SHFB/Source/SandcastleCore/BuildAssembler/BuildComponent/BuildComponentFactory.cs
+++ b/SHFB/Source/SandcastleCore/BuildAssembler/BuildComponent/BuildComponentFactory.cs
@@ -115,12 +115,16 @@ namespace Sandcastle.Core.BuildAssembler.BuildComponent
         /// <remarks>The base implementation uses a generic editor dialog that edits the XML as text</remarks>
         public virtual string ConfigureComponent(string currentConfiguration, CompositionContainer container)
         {
+        #if DOTNETCORE
+            return "";
+        #else
             var dlg = new ConfigurationEditorDlg() { Configuration = currentConfiguration };
 
             if(dlg.ShowModalDialog() ?? false)
                 currentConfiguration = dlg.Configuration;
 
             return currentConfiguration;
+        #endif
         }
         #endregion
     }

--- a/SHFB/Source/SandcastleCore/Sandcastle.Core-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleCore/Sandcastle.Core-DotNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>SandcastleBuilder.Core</RootNamespace>
     <PackageId>SandcastleBuilder.Core</PackageId>
     <Authors>Eric Woodruff</Authors>
@@ -13,10 +13,8 @@
     <PackageProjectUrl>https://github.com/EWSoftware/SHFB</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EWSoftware/SHFB</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <PackageTags>Sandcastle;Help;Builder;Utilities</PackageTags>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Version>19.11.17</Version>
     <InformationalVersion Condition="'$(Configuration)'=='Release'">Release Build</InformationalVersion>
@@ -43,7 +41,6 @@
     <Compile Remove="WpfHelpers.cs" />
     <None Remove="Properties\**" />
     <None Remove="Resources\**" />
-    <None Remove="**\*.targets" />
     <None Remove="BuildAssembler\BuildComponent\ConfigurationEditorDlg.xaml" />
     <None Remove="packages.config" />
   </ItemGroup>

--- a/SHFB/Source/SandcastleCore/Sandcastle.Core-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleCore/Sandcastle.Core-DotNetCore.csproj
@@ -22,9 +22,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Sandcastle.Core</AssemblyName>
+    <AssemblyName>SandcastleBuilder.Core</AssemblyName>
     <OutputPath>bin\$(Configuration)</OutputPath>
-    <DocumentationFile>$(OutputPath)\Sandcastle.Core.xml</DocumentationFile>
+    <DocumentationFile>$(OutputPath)\$(TargetFramework)\SandcastleBuilder.Core.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netcore'))">

--- a/SHFB/Source/SandcastleCore/Sandcastle.Core-DotNetCore.csproj
+++ b/SHFB/Source/SandcastleCore/Sandcastle.Core-DotNetCore.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>SandcastleBuilder.Core</RootNamespace>
+    <PackageId>SandcastleBuilder.Core</PackageId>
+    <Authors>Eric Woodruff</Authors>
+    <Company>Eric Woodruff</Company>
+    <Product>Sandcastle</Product>
+    <PackageDescription>Sandcastle Help File Builder and Tools</PackageDescription>
+    <Description>This assembly contains the project, build engine, and Managed Extensibility Framework (MEF) classes used by all of the other Sandcastle Help File Builder applications.</Description>
+    <Copyright>Copyright © 2006-2020, Eric Woodruff, All Rights Reserved</Copyright>
+    <PackageProjectUrl>https://github.com/EWSoftware/SHFB</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/EWSoftware/SHFB</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
+    <PackageTags>Sandcastle;Help;Builder;Utilities</PackageTags>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Version>19.11.17</Version>
+    <InformationalVersion Condition="'$(Configuration)'=='Release'">Release Build</InformationalVersion>
+    <InformationalVersion Condition="'$(Configuration)'!='Release'">Debug Build</InformationalVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyName>Sandcastle.Core</AssemblyName>
+    <OutputPath>bin\$(Configuration)</OutputPath>
+    <DocumentationFile>$(OutputPath)\Sandcastle.Core.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcore'))">
+    <DefineConstants>DOTNETCORE</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Exclude unused / unavailable code items -->
+  <ItemGroup>
+    <EmbeddedResource Remove="Properties\**" />
+    <EmbeddedResource Remove="Resources\**" />
+    <Compile Remove="Properties\**" />
+    <Compile Remove="Resources\**" />
+    <Compile Remove="BuildAssembler\BuildComponent\ConfigurationEditorDlg.xaml.cs" />
+    <Compile Remove="WpfHelpers.cs" />
+    <None Remove="Properties\**" />
+    <None Remove="Resources\**" />
+    <None Remove="**\*.targets" />
+    <None Remove="BuildAssembler\BuildComponent\ConfigurationEditorDlg.xaml" />
+    <None Remove="packages.config" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This is a non-breaking simple set of additions to create a dotnet core based MSBuild task so multi-targeted build options can be tested. This is to allow `dotnet build` to work on a Visual Studio solution that references a Sandcastle project, see issue #517