### PR TITLE
Facilitate Debugging SHFB Tools NuGet Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+/NuGet/DebugNuGet.bat

--- a/NuGet/SHFB.nuspec
+++ b/NuGet/SHFB.nuspec
@@ -19,7 +19,7 @@
 				 only need to install the packages that you actually need. -->
 	</metadata>
 	<files>
-		<file src="..\SHFB\Deploy\**\*" target="tools" exclude="..\SHFB\Deploy\Data\**\*;..\SHFB\Deploy\Extras\**\*;..\SHFB\Deploy\Help\**\*;..\SHFB\Deploy\Schemas\**\*;..\SHFB\Deploy\Snippets\**\*;..\SHFB\Deploy\Tools\**\*;..\SHFB\Deploy\**\.gitignore;..\SHFB\Deploy\**\*.pdb" />
+		<file src="..\SHFB\Deploy\**\*" target="tools" exclude="..\SHFB\Deploy\Data\**\*;..\SHFB\Deploy\Extras\**\*;..\SHFB\Deploy\Help\**\*;..\SHFB\Deploy\Schemas\**\*;..\SHFB\Deploy\Snippets\**\*;..\SHFB\Deploy\Tools\**\*;..\SHFB\Deploy\**\.gitignore" />
 		<file src="..\SHFB\Deploy\Tools\HelpLibraryManagerLauncher.exe*" target="tools\Tools" />
 		<file src="ReadMe.md" target="ReadMe.md" />
 		<file src="EWSoftware.SHFB.props" target="build" />

--- a/SHFB/Source/MRefBuilder/MRefBuilder.cs
+++ b/SHFB/Source/MRefBuilder/MRefBuilder.cs
@@ -30,10 +30,10 @@ using System.Xml.XPath;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Sandcastle.Tools.Reflection;
 
 using Sandcastle.Core;
 using Sandcastle.Core.Reflection;
+using Sandcastle.Tools.Reflection;
 
 namespace Sandcastle.Tools.MSBuild
 {
@@ -85,7 +85,7 @@ namespace Sandcastle.Tools.MSBuild
         /// <summary>
         /// This is used to indicate whether or not to wait for the debugger to attach to the process
         /// </summary>
-        public bool WaitForDebugger { get; set; }
+        public bool WaitForDebugger = true;
 #endif
         #endregion
 

--- a/SHFB/Source/MRefBuilder/MRefBuilder.cs
+++ b/SHFB/Source/MRefBuilder/MRefBuilder.cs
@@ -80,13 +80,6 @@ namespace Sandcastle.Tools.MSBuild
         /// </summary>
         /// <value>References are optional</value>
         public ITaskItem[] References { get; set; }
-
-#if DEBUG
-        /// <summary>
-        /// This is used to indicate whether or not to wait for the debugger to attach to the process
-        /// </summary>
-        public bool WaitForDebugger { get; set; } = true;
-#endif
         #endregion
 
         #region ICancelableTask Members
@@ -117,26 +110,23 @@ namespace Sandcastle.Tools.MSBuild
         {
             string currentDirectory = null;
             bool success = false;
-#if DEBUG
-            if(this.WaitForDebugger)
+#if DEBUG && WAIT_FOR_DEBUGGER
+            while(!Debugger.IsAttached && !waitCancelled)
             {
-                while(!Debugger.IsAttached && !waitCancelled)
-                {
 #if NET9_0_OR_GREATER
                     this.Log.LogMessage("DEBUG MODE: Waiting for debugger to attach (process ID: {0})",
                         Environment.ProcessId);
 #else
-                    this.Log.LogMessage("DEBUG MODE: Waiting for debugger to attach (process ID: {0})",
-                        Process.GetCurrentProcess().Id);
+                this.Log.LogMessage("DEBUG MODE: Waiting for debugger to attach (process ID: {0})",
+                    Process.GetCurrentProcess().Id);
 #endif
-                    System.Threading.Thread.Sleep(1000);
-                }
-
-                if(waitCancelled)
-                    return false;
-
-                Debugger.Break();
+                System.Threading.Thread.Sleep(1000);
             }
+
+            if(waitCancelled)
+                return false;
+
+            Debugger.Break();
 #endif
             Assembly application = Assembly.GetCallingAssembly();
             System.Reflection.AssemblyName applicationData = application.GetName();

--- a/SHFB/Source/MRefBuilder/MRefBuilder.cs
+++ b/SHFB/Source/MRefBuilder/MRefBuilder.cs
@@ -85,7 +85,7 @@ namespace Sandcastle.Tools.MSBuild
         /// <summary>
         /// This is used to indicate whether or not to wait for the debugger to attach to the process
         /// </summary>
-        public bool WaitForDebugger = true;
+        public bool WaitForDebugger { get; set; } = true;
 #endif
         #endregion
 

--- a/SHFB/Source/MRefBuilder/MRefBuilder.csproj
+++ b/SHFB/Source/MRefBuilder/MRefBuilder.csproj
@@ -17,9 +17,14 @@
 		<RootNamespace>Sandcastle.Tools.MSBuild</RootNamespace>
 		<!-- For this, we want all of the dependency assemblies so that the dotnet tool can find them (NetCore builds) -->
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<Configurations>Debug;Release;Wait For Debugger</Configurations>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Wait For Debugger|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -31,8 +36,20 @@
 		<OutputPath>..\..\Deploy\</OutputPath>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Wait For Debugger|AnyCPU'">
+	  <OutputPath>..\..\Deploy\</OutputPath>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<OutputPath>..\..\Deploy\</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Wait For Debugger|net48|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Wait For Debugger|net9.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SHFB/Source/SandcastleBuilderMSBuild/BuildEngine/BuildAssemblerInternal.cs
+++ b/SHFB/Source/SandcastleBuilderMSBuild/BuildEngine/BuildAssemblerInternal.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Threading;
@@ -163,6 +164,21 @@ namespace SandcastleBuilder.MSBuild.BuildEngine
         /// <inheritdoc />
         public void AddComponents(XPathNavigator configuration)
         {
+#if DEBUG && WAIT_FOR_DEBUGGER
+            while(!Debugger.IsAttached)
+            {
+#if NET9_0_OR_GREATER
+                Console.WriteLine("DEBUG MODE: Waiting for debugger to attach (process ID: {0})",
+                        Environment.ProcessId);
+#else
+                Console.WriteLine("DEBUG MODE: Waiting for debugger to attach (process ID: {0})",
+                        Process.GetCurrentProcess().Id);
+#endif
+                System.Threading.Thread.Sleep(1000);
+            }
+
+            Debugger.Break();
+#endif
             components.AddRange(this.LoadComponents(configuration));
         }
 

--- a/SHFB/Source/SandcastleBuilderMSBuild/SandcastleBuilderMSBuild.csproj
+++ b/SHFB/Source/SandcastleBuilderMSBuild/SandcastleBuilderMSBuild.csproj
@@ -14,14 +14,27 @@
 		<RootNamespace>SandcastleBuilder.MSBuild</RootNamespace>
 		<!-- For this, we want all of the dependency assemblies so that the dotnet tool can find them (NetCore builds) -->
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<Configurations>Debug;Release;Wait For Debugger</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\..\Deploy\</OutputPath>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Wait For Debugger|AnyCPU'">
+	  <OutputPath>..\..\Deploy\</OutputPath>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<OutputPath>..\..\Deploy\</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Wait For Debugger|net48|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Wait For Debugger|net9.0|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SHFB/Source/SandcastleTools.slnx
+++ b/SHFB/Source/SandcastleTools.slnx
@@ -11,13 +11,17 @@
   <Project Path="BuildAssembler/SyntaxComponents/SyntaxComponents.csproj" />
   <Project Path="CodeColorizer/ColorizerLibrary/ColorizerLibrary.csproj" />
   <Project Path="HelpLibraryManagerLauncher/HelpLibraryManagerLauncher.csproj" />
-  <Project Path="MRefBuilder/MRefBuilder.csproj" />
+  <Project Path="MRefBuilder/MRefBuilder.csproj">
+    <BuildType Solution="Debug|*" Project="Wait For Debugger" />
+  </Project>
   <Project Path="PresentationStyles/PresentationStyles.csproj" />
   <Project Path="ReflectionDataManager/ReflectionDataManager.csproj" />
   <Project Path="SandcastleBuilderGUI/SandcastleBuilderGui.csproj">
     <BuildDependency Project="CodeColorizer/ColorizerLibrary/ColorizerLibrary.csproj" />
   </Project>
-  <Project Path="SandcastleBuilderMSBuild/SandcastleBuilderMSBuild.csproj" />
+  <Project Path="SandcastleBuilderMSBuild/SandcastleBuilderMSBuild.csproj">
+    <BuildType Solution="Debug|*" Project="Wait For Debugger" />
+  </Project>
   <Project Path="SandcastleBuilderPlugIns/SandcastleBuilderPlugIns.csproj" />
   <Project Path="SandcastleBuilderPlugInsUI/SandcastleBuilderPlugInsUI.csproj" />
   <Project Path="SandcastleBuilderWPF/SandcastleBuilderWPF_GUI.csproj" />


### PR DESCRIPTION
Simplifies attaching the debugger to the tools assemblies to debug issues that arise executing SHFB NuGet package.

Two project configurations were modified to add "Wait For Debugger". Release and Debug project configurations are unchanged.

The SHFB nuspec file was modified so project PDB files are added to the NuGet package. A side effect of this change is the nupkg file increased in size by around 2MB.