### PR TITLE
Refactor DefaultTopicFile to use auto-implemented syntax

### DIFF
--- a/SHFB/Source/SandcastleBuilderMSBuild/BuildEngine/BuildProcess.cs
+++ b/SHFB/Source/SandcastleBuilderMSBuild/BuildEngine/BuildProcess.cs
@@ -426,11 +426,7 @@ namespace SandcastleBuilder.MSBuild.BuildEngine
         /// This returns the filename of the default topic as determined by the build engine
         /// </summary>
         /// <remarks>The path is relative to the root of the output folder (i.e. html/DefaultTopic.htm)</remarks>
-        public string DefaultTopicFile
-        {
-            get => field ?? String.Empty;
-            private set => field = value;
-        }
+        public string DefaultTopicFile { get; private set; }
 
         /// <summary>
         /// This returns the <see cref="SandcastleProject.HelpTitle"/> project property value with all


### PR DESCRIPTION
Updated the `DefaultTopicFile` property to utilize auto-implemented property syntax. This change simplifies the code by removing the backing field and explicit getter/setter methods, enhancing readability and maintainability.

This fix provides the desired behavior when a default topic has not been marked. It will now return null in that scenario and allow the build process to attempt to determine a default topic or throw the BE0026 exception if that fails.

Fixes #1136.