### PR TITLE
Fix file path separators in sourceFile handling

### DIFF
--- a/SHFB/Source/BuildAssembler/BuildComponents/CodeBlockComponent.cs
+++ b/SHFB/Source/BuildAssembler/BuildComponents/CodeBlockComponent.cs
@@ -855,7 +855,7 @@ namespace Sandcastle.Tools.BuildComponents
             XmlAttribute srcFile = code.Attributes["source"];
 
             if(srcFile != null)
-                sourceFile = srcFile.Value;
+                sourceFile = srcFile.Value.CorrectFilePathSeparators();
 
             if(String.IsNullOrWhiteSpace(sourceFile))
             {


### PR DESCRIPTION
Updated the `sourceFile` variable to use the `CorrectFilePathSeparators()` method on the value retrieved from the `srcFile` attribute. This change improves compatibility across different operating systems by ensuring correct file path formatting.

Found while debugging NuGet package running under Linux. The "source" attribute in MAML conceptual content may contain Windows path separators.