### PR TITLE
Correct file path separators in OutputPath retrieved from SHFB projec…

### DIFF
--- a/SHFB/Source/SandcastleBuilderMSBuild/HelpProject/SandcastleProject.cs
+++ b/SHFB/Source/SandcastleBuilderMSBuild/HelpProject/SandcastleProject.cs
@@ -583,7 +583,7 @@ namespace SandcastleBuilder.MSBuild.HelpProject
                 else
                     value = FolderPath.TerminatePath(value);
 
-                field = value;
+                field = value.CorrectFilePathSeparators();
             }
         }
 


### PR DESCRIPTION
This pull request fixes issue with Windows file path separators becoming a part of the directory name, e.g. "Help\\" Linux based builds and build servers. WorkingPath appears to be OK.

Tested with dotnet command line on Windows developer command prompts, WSL/Ubuntu, and Github workflow running Ubuntu.

Closes issue #1151 