### PR TITLE
Markdown: Provide an inclusion block extension for SHFB

### DIFF
--- a/SHFB/Source/SandcastleBuilderMSBuild/BuildEngine/ConceptualContentSettings.cs
+++ b/SHFB/Source/SandcastleBuilderMSBuild/BuildEngine/ConceptualContentSettings.cs
@@ -32,6 +32,7 @@ using System.Xml;
 using Sandcastle.Core;
 using Sandcastle.Core.BuildEngine;
 using Sandcastle.Core.ConceptualContent;
+using Sandcastle.Core.Markdown.Extensions.Inclusion;
 using Sandcastle.Core.Project;
 
 using SandcastleBuilder.MSBuild.HelpProject;
@@ -373,7 +374,13 @@ public class ConceptualContentSettings : IConceptualContentSettings
                 File.SetAttributes(destFile, FileAttributes.Normal);
             }
             else
+            {
                 File.WriteAllText(destFile, builder.MarkdownToMamlConverter.ConvertFromFile(t.Id, t.TopicFile.FullPath));
+                foreach (ParseMessages message in builder.MarkdownToMamlConverter.Warnings)
+                {
+                    builder.ReportWarning(message.Code, message.Message);
+                }
+            }
 
             // Add referenced namespaces to the build process
             var rn = builder.ReferencedNamespaces;

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/ExtensionsHelper.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/ExtensionsHelper.cs
@@ -1,0 +1,236 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : ExtensionsHelper.cs
+// Author  : .NET Foundation
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// Extensions for parsing markdown strings.
+//
+// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you
+// under the MIT license.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code based on https://github.com/dotnet/docfx/commits/2a436495ed0716eebbc7eaad84d652f18600c2f6/
+//===============================================================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Markdig.Helpers;
+
+namespace Sandcastle.Core.Markdown.Extensions;
+
+/// <summary>
+/// Helper classes for markdown extensions.
+/// </summary>
+public static class ExtensionsHelper
+{
+    /// <summary>
+    /// Matches the start of the current string slice with a given string.
+    /// </summary>
+    /// <param name="slice">The markdown string slice.</param>
+    /// <param name="startString">The start string to match.</param>
+    /// <param name="isCaseSensitive">if set to <see langword="true"/> then perform a case insensitive search.</param>
+    /// <returns><see langword="true"/> if there is a match, <see langword="false"/> otherwise.</returns>
+    public static bool MatchStart(ref StringSlice slice, string startString, bool isCaseSensitive = true)
+    {
+        var c = slice.CurrentChar;
+        var index = 0;
+
+        while(c != '\0' && index < startString.Length && CharEqual(c, startString[index], isCaseSensitive))
+        {
+            c = slice.NextChar();
+            index++;
+        }
+
+        return index == startString.Length;
+    }
+
+    /// <summary>
+    /// Matches the inclusion end character.
+    /// </summary>
+    /// <param name="slice">The markdown string slice.</param>
+    /// <returns><see langword="true"/> if there is a match, <see langword="false"/> otherwise.</returns>
+    public static bool MatchInclusionEnd(ref StringSlice slice)
+    {
+        if(slice.CurrentChar != ']')
+        {
+            return false;
+        }
+
+        slice.NextChar();
+
+        return true;
+    }
+
+    /// <summary>
+    /// Matches a link template in the form of `[title](path)` and extracts the title and path. The title is optional,
+    /// but if present must be in square brackets. The path is required and must be in parentheses. The path can
+    /// optionally be enclosed in angle brackets. If the path is not enclosed in angle brackets, then it can contain a
+    /// title after the path, which will be ignored. The method returns <see langword="true"/> if a link template is
+    /// matched, <see langword="false"/> otherwise. If a match is found, the title and path are extracted and returned
+    /// via the <paramref name="title"/> and <paramref name="path"/> parameters.
+    /// </summary>
+    /// <param name="slice">The markdown string slice.</param>
+    /// <param name="title">The extracted title.</param>
+    /// <param name="path">The extracted path.</param>
+    /// <returns><see langword="true"/> if there is a match, <see langword="false"/> otherwise.</returns>
+    public static bool MatchLink(ref StringSlice slice, ref string title, ref string path)
+    {
+        if(MatchTitle(ref slice, ref title) && MatchPath(ref slice, ref path))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool MatchTitle(ref StringSlice slice, ref string title)
+    {
+        SkipSpace(ref slice);
+
+        if(slice.CurrentChar != '[')
+        {
+            return false;
+        }
+
+        var c = slice.NextChar();
+        var str = StringBuilderCache.Local();
+        var hasEscape = false;
+
+        while(c != '\0' && (c != ']' || hasEscape))
+        {
+            if(c == '\\' && !hasEscape)
+            {
+                hasEscape = true;
+            }
+            else
+            {
+                str.Append(c);
+                hasEscape = false;
+            }
+            c = slice.NextChar();
+        }
+
+        if(c == ']')
+        {
+            title = str.ToString().Trim();
+            slice.NextChar();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool MatchPath(ref StringSlice slice, ref string path)
+    {
+        if(slice.CurrentChar != '(')
+        {
+            return false;
+        }
+
+        slice.NextChar();
+        SkipWhitespace(ref slice);
+
+        string includedFilePath;
+        if(slice.CurrentChar == '<')
+        {
+            includedFilePath = TryGetStringBeforeChars([')', '>'], ref slice, breakOnWhitespace: true);
+        }
+        else
+        {
+            includedFilePath = TryGetStringBeforeChars([')'], ref slice, breakOnWhitespace: true);
+        }
+
+        if(includedFilePath is null)
+        {
+            return false;
+        }
+
+        if(includedFilePath.Length >= 1 && includedFilePath.First() == '<' && slice.CurrentChar == '>')
+        {
+            includedFilePath = includedFilePath.Substring(1).Trim();
+        }
+
+        if(slice.CurrentChar == ')')
+        {
+            path = includedFilePath;
+            slice.NextChar();
+            return true;
+        }
+        else
+        {
+            var title = TryGetStringBeforeChars([')'], ref slice, breakOnWhitespace: false);
+            if(title is null)
+            {
+                return false;
+            }
+            else
+            {
+                path = includedFilePath;
+                slice.NextChar();
+                return true;
+            }
+        }
+    }
+
+    private static void SkipSpace(ref StringSlice slice)
+    {
+        while(slice.CurrentChar == ' ')
+        {
+            slice.NextChar();
+        }
+    }
+
+    private static void SkipWhitespace(ref StringSlice slice)
+    {
+        var c = slice.CurrentChar;
+        while(c != '\0' && c.IsWhitespace())
+        {
+            c = slice.NextChar();
+        }
+    }
+    private static bool CharEqual(char ch1, char ch2, bool isCaseSensitive)
+    {
+        return isCaseSensitive ? ch1 == ch2 : Char.ToLower(ch1) == Char.ToLower(ch2);
+    }
+
+    private static string TryGetStringBeforeChars(IReadOnlyList<char> chars, ref StringSlice slice, bool breakOnWhitespace = false)
+    {
+        StringSlice savedSlice = slice;
+        var c = slice.CurrentChar;
+        var hasEscape = false;
+        var builder = StringBuilderCache.Local();
+
+        while(c != '\0' && (!breakOnWhitespace || !c.IsWhitespace()) && (hasEscape || !chars.Contains(c)))
+        {
+            if(c == '\\' && !hasEscape)
+            {
+                hasEscape = true;
+            }
+            else
+            {
+                builder.Append(c);
+                hasEscape = false;
+            }
+            c = slice.NextChar();
+        }
+
+        if(c == '\0' && !chars.Contains('\0'))
+        {
+            slice = savedSlice;
+            builder.Length = 0;
+            return null;
+        }
+        else
+        {
+            var result = builder.ToString().Trim();
+            builder.Length = 0;
+            return result;
+        }
+    }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlock.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlock.cs
@@ -1,0 +1,112 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : InclusionBlock.cs
+// Author  : .NET Foundation
+// Updated : 04/54/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// An inclusion block added to the Markdig AST.
+//
+// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you
+// under the MIT license.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code based on https://github.com/dotnet/docfx/commits/2a436495ed0716eebbc7eaad84d652f18600c2f6/
+//===============================================================================================================
+
+using System;
+using System.IO;
+
+using Markdig;
+using Markdig.Parsers;
+using Markdig.Syntax;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// An inclusion block, creating while parsing from <see cref="InclusionBlockParser"/>.
+/// </summary>
+public class InclusionBlock : ContainerBlock
+{
+    /// <summary>
+    /// Gets or sets the title by the inclusion block.
+    /// </summary>
+    /// <value>The title in the inclusion block text.</value>
+    public string Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the included file path given by the user.
+    /// </summary>
+    /// <value>The included file path.</value>
+    public string IncludedFilePath { get; set; }
+
+    /// <summary>
+    /// Gets the resolved file path as obtained by this block.
+    /// </summary>
+    /// <value>The resolved file path.</value>
+    public string ResolvedFilePath { get; private set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this <see cref="InclusionBlock"/> is loaded.
+    /// </summary>
+    /// <value><see langword="true"/> if loaded; otherwise, <see langword="false"/>.</value>
+    public bool Loaded { get; set; }
+
+    /// <summary>
+    /// Gets the raw token.
+    /// </summary>
+    /// <returns>The raw token, useful for errors.</returns>
+    public string GetRawToken() => $"[!INCLUDE[{Title}]({IncludedFilePath})]";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InclusionBlock"/> class.
+    /// </summary>
+    /// <param name="parser">The parser used to create this block.</param>
+    public InclusionBlock(BlockParser parser) : base(parser)
+    {
+
+    }
+
+    /// <summary>
+    /// Loads the markdown file that this inclusion block points to, and adds the blocks in the file to this block.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    public void Load(MarkdownPipeline pipeline)
+    {
+        if(Loaded)
+        {
+            return;
+        }
+
+        try
+        {
+            using var path = InclusionFiles.PushDependency(IncludedFilePath);
+
+            ResolvedFilePath = path.FilePath;
+            string content = ReadFile(ResolvedFilePath);
+            MarkdownDocument document = Markdig.Markdown.Parse(content, pipeline);
+
+            // A foreach() won't work as expected, skipping some blocks.
+            while(document.Count > 0)
+            {
+                Block block = document[0];
+                document.RemoveAt(0);
+                this.Add(block);
+            }
+            Loaded = true;
+        }
+        catch(ArgumentException ex)
+        {
+            // TODO: To add 
+            //   builder.ReportWarning("BE0076", ex.Message);
+            Console.WriteLine(ex.Message);
+            return;
+        }
+    }
+
+    private static string ReadFile(string path)
+    {
+        return File.ReadAllText(path);
+    }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlock.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlock.cs
@@ -98,9 +98,11 @@ public class InclusionBlock : ContainerBlock
         }
         catch(ArgumentException ex)
         {
-            // TODO: To add 
-            //   builder.ReportWarning("BE0076", ex.Message);
-            Console.WriteLine(ex.Message);
+            return;
+        }
+        catch(Exception ex)
+        {
+            InclusionFiles.Warnings.Add(new("BE0076", ex.Message));
             return;
         }
     }

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlockParser.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlockParser.cs
@@ -1,0 +1,92 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : InclusionBlockParser.cs
+// Author  : .NET Foundation
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// Block parser for inclusion blocks.
+//
+// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you
+// under the MIT license.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code based on https://github.com/dotnet/docfx/commits/2a436495ed0716eebbc7eaad84d652f18600c2f6/
+//===============================================================================================================
+
+using Markdig.Helpers;
+using Markdig.Parsers;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// Markdig block parser for inclusion blocks '[!INCLUDE [&lt;title&gt;](&lt;filepath&gt;)]'.
+/// </summary>
+public class InclusionBlockParser : BlockParser
+{
+    private const string StartString = "[!include";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InclusionBlockParser"/> class.
+    /// </summary>
+    public InclusionBlockParser()
+    {
+        // important: if you don't set this, the parser won't be called!
+        OpeningCharacters = ['['];
+    }
+
+    /// <summary>
+    /// Tries to match a block opening.
+    /// </summary>
+    /// <param name="processor">The parser processor.</param>
+    /// <returns>The result of the match.</returns>
+    public override BlockState TryOpen(BlockProcessor processor)
+    {
+        // stop processing if we're in a code block
+        if(processor.IsCodeIndent)
+        {
+            return BlockState.None;
+        }
+
+        // [!include[<title>](<filepath>)]
+        int column = processor.Column;
+        StringSlice line = processor.Line;
+
+        if(!ExtensionsHelper.MatchStart(ref line, StartString, false))
+        {
+            return BlockState.None;
+        }
+        else
+        {
+            if(line.CurrentChar == '+')
+            {
+                line.NextChar();
+            }
+        }
+
+        string title = null, path = null;
+
+        if(!ExtensionsHelper.MatchLink(ref line, ref title, ref path) || !ExtensionsHelper.MatchInclusionEnd(ref line))
+        {
+            return BlockState.None;
+        }
+
+        while(line.CurrentChar.IsSpaceOrTab()) line.NextChar();
+        if(line.CurrentChar != '\0')
+        {
+            return BlockState.None;
+        }
+
+        InclusionBlock incBlock = new(this)
+        {
+            Title = title,
+            IncludedFilePath = path,
+            Line = processor.LineIndex,
+            Column = column,
+        };
+        processor.NewBlocks.Push(incBlock);
+
+        return BlockState.BreakDiscard;
+    }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlockRenderer.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionBlockRenderer.cs
@@ -1,0 +1,65 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : InclusionBlockRenderer.cs
+// Author  : Jason Curl (jcurl@arcor.de)
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// Renders an inclusion block.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code
+//===============================================================================================================
+
+using Markdig;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// Block renderer for the <see cref="InclusionBlock"/>.
+/// </summary>
+/// <remarks>
+/// It delegates rendering to all the blocks the inclusion block contains.
+/// </remarks>
+public class InclusionBlockRenderer : HtmlObjectRenderer<InclusionBlock>
+{
+    private readonly MarkdownPipeline _pipeline;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InclusionBlockRenderer"/> class.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    public InclusionBlockRenderer(MarkdownPipeline pipeline)
+    {
+        _pipeline = pipeline;
+    }
+
+    /// <summary>
+    /// Renders the inclusion block.
+    /// </summary>
+    /// <param name="renderer">The renderer.</param>
+    /// <param name="inclusion">The inclusion block.</param>
+    protected override void Write(HtmlRenderer renderer, InclusionBlock inclusion)
+    {
+        if(!inclusion.Loaded)
+        {
+            renderer.Write(inclusion.GetRawToken());
+        }
+        else
+        {
+            foreach(Block block in inclusion)
+            {
+                renderer.Write(block);
+            }
+        }
+    }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionExtension.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionExtension.cs
@@ -1,0 +1,83 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : InclusionBlockExtension.cs
+// Author  : .NET Foundation
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// An inclusion block added to the Markdig AST.
+//
+// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you
+// under the MIT license.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code based on https://github.com/dotnet/docfx/commits/2a436495ed0716eebbc7eaad84d652f18600c2f6/
+//===============================================================================================================
+
+using System.Linq;
+
+using Markdig;
+using Markdig.Renderers;
+using Markdig.Syntax;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// Markdown inclusion extension to add to a pipeline.
+/// </summary>
+public class InclusionExtension : IMarkdownExtension
+{
+    private MarkdownPipeline _pipeline;
+
+    /// <summary>
+    /// Setups this extension for the specified pipeline.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    /// <remarks>
+    /// To load the inclusion blocks when loading the file, you must also set up the renderer. The setup doesn't provide
+    /// the pipeline which is required when loading a new markdown file. The renderer does have the pipeline. This may
+    /// be strange, Markdig never intended to load markdown files during parsing. Other porjects (docfx) loads the file
+    /// during rendering that prevents processing before rendering, needing a lot of invasive changes in the caller.
+    /// </remarks>
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        pipeline
+            .BlockParsers
+            .AddIfNotAlready(new InclusionBlockParser());
+
+        pipeline.DocumentProcessed += document =>
+        {
+            // Pipeline set up when renderer is configured.
+            ProcessInclusions(document, _pipeline);
+        };
+    }
+
+    /// <summary>
+    /// Setups this extension for the specified renderer.
+    /// </summary>
+    /// <param name="pipeline">The pipeline used to parse the document.</param>
+    /// <param name="renderer">The renderer.</param>
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+        _pipeline = pipeline;
+
+        if(renderer is HtmlRenderer htmlRenderer)
+        {
+            if(!htmlRenderer.ObjectRenderers.Contains<InclusionBlockRenderer>())
+            {
+                htmlRenderer.ObjectRenderers.Insert(0, new InclusionBlockRenderer(pipeline));
+            }
+        }
+    }
+
+    private static void ProcessInclusions(MarkdownDocument document, MarkdownPipeline pipeline)
+    {
+        var inclusions = document.Descendants<InclusionBlock>().ToList();
+
+        foreach(var inclusion in inclusions)
+        {
+            inclusion.Load(pipeline);
+        }
+    }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionFileContext.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionFileContext.cs
@@ -1,0 +1,49 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : InclusionFileContext.cs
+// Author  : Jason Curl (jcurl@arcor.de)
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// Manages context information about included files.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code
+//===============================================================================================================
+
+using System;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// A context that can be disposed when pushing an included file.
+/// </summary>
+public readonly struct InclusionFileContext : IDisposable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InclusionFileContext"/> struct.
+    /// </summary>
+    /// <param name="filePath">The file path.</param>
+    public InclusionFileContext(string filePath)
+    {
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Gets the file path.
+    /// </summary>
+    /// <value>The file path.</value>
+    public string FilePath { get; }
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting managed, or unmanaged
+    /// resources.
+    /// </summary>
+    public void Dispose() => InclusionFiles.Pop();
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionFiles.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionFiles.cs
@@ -1,0 +1,124 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : InclusionFiles.cs
+// Author  : Jason Curl (jcurl@arcor.de)
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// Manages global information about included files.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code
+//===============================================================================================================
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// Class InclusionFiles.
+/// </summary>
+/// <remarks>
+/// Manages the stack of files being included and detects circular references. It also ensures that all file paths are
+/// absolute and normalized to avoid issues with different relative paths referring to the same file. The first file is
+/// pushed using <see cref="PushFile(String)"/> and all subsequent files are pushed using
+/// <see cref="PushDependency(String)"/>. When done with a file, call <see cref="Pop"/> to remove it from the stack and
+/// allow it to be included again if needed.
+/// </remarks>
+public static class InclusionFiles
+{
+    private static readonly HashSet<string> files = new(StringComparer.InvariantCultureIgnoreCase);
+    private static readonly Stack<string> stack = new();
+
+    /// <summary>
+    /// Initialises the stack with the first file to be included. This should be called once for the main file.
+    /// </summary>
+    /// <param name="fileName">Name of the file.</param>
+    /// <returns>The fully qualified path name.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="fileName"/> is not a valid path.</exception>
+    public static string PushFile(string fileName)
+    {
+        if(fileName is null) throw new ArgumentNullException(nameof(fileName));
+
+        string fullPath;
+        if(Path.IsPathRooted(fileName))
+        {
+            fullPath = Path.GetFullPath(fileName);
+        }
+        else
+        {
+            fullPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, fileName));
+        }
+
+        files.Clear();
+        stack.Clear();
+        files.Add(fullPath);
+        stack.Push(fullPath);
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Pushes a file dependency to the stack dependency.
+    /// </summary>
+    /// <param name="fileName">Name of the file that is included from the previous file pushed.</param>
+    /// <returns>A context that can be disposed, which then pops the context.</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="fileName"/> is not a valid relative path.
+    /// <para>- or -</para>
+    /// Circular reference detected.
+    /// <para>- or -</para>
+    /// File not found.
+    /// </exception>
+    public static InclusionFileContext PushDependency(string fileName)
+    {
+        if(Path.IsPathRooted(fileName))
+        {
+            throw new ArgumentException($"File name '{fileName}' is not a valid relative path", nameof(fileName));
+        }
+
+        string prevPath = stack.Peek();
+        string newPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(prevPath), fileName));
+        if(files.Contains(newPath))
+        {
+            // TODO: Provide the circular reference.
+            throw new ArgumentException("Circular reference detected", nameof(fileName));
+        }
+
+        if(!File.Exists(newPath))
+        {
+            throw new ArgumentException($"File not found: '{newPath}'", nameof(fileName));
+        }
+
+        stack.Push(newPath);
+        files.Add(newPath);
+        return new(newPath);
+    }
+
+    /// <summary>
+    /// Pops the current file from the stack.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No file to pop,</exception>
+    /// <remarks>
+    /// Normally not needed to call this directly, as the context returned from <see cref="PushDependency(String)"/>
+    /// will pop the file when disposed.
+    /// </remarks>
+    public static void Pop()
+    {
+        if(stack.Count <= 1)
+        {
+            throw new InvalidOperationException("No file to pop");
+        }
+
+        string popped = stack.Pop();
+        files.Remove(popped);
+    }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionFiles.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/InclusionFiles.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
 
@@ -37,6 +38,12 @@ public static class InclusionFiles
 {
     private static readonly HashSet<string> files = new(StringComparer.InvariantCultureIgnoreCase);
     private static readonly Stack<string> stack = new();
+
+    /// <summary>
+    /// Gets a list of warnings when parsing this node.
+    /// </summary>
+    /// <value>The list of warnings.</value>
+    public static IList<ParseMessages> Warnings { get; } = [];
 
     /// <summary>
     /// Initialises the stack with the first file to be included. This should be called once for the main file.
@@ -87,14 +94,29 @@ public static class InclusionFiles
 
         string prevPath = stack.Peek();
         string newPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(prevPath), fileName));
+
         if(files.Contains(newPath))
         {
-            // TODO: Provide the circular reference.
+            string[] files = stack.ToArray();
+            StringBuilder circularReferences = new();
+            for (int s = files.Length - 1; s > 0; s--) {
+                if(s != files.Length) circularReferences.Append("<-- ");
+                circularReferences.AppendLine(files[s]);
+            }
+            Warnings.Add(new("BE0077",
+                $"The conceptual topic file '{files[0]}' has circular references includes. " + 
+                $"The generated topic file may be incomplete.\n{circularReferences}"));
+
             throw new ArgumentException("Circular reference detected", nameof(fileName));
         }
 
         if(!File.Exists(newPath))
         {
+            string[] files = stack.ToArray();
+            Warnings.Add(new("BE0076",
+                $"The conceptual topic file '{files[0]}' has missing includes. " +
+                $"The generated topic file may be incomplete. Missing file {newPath} " +
+                $"from file {prevPath}"));
             throw new ArgumentException($"File not found: '{newPath}'", nameof(fileName));
         }
 

--- a/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/ParseMessages.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/Extensions/Inclusion/ParseMessages.cs
@@ -1,0 +1,43 @@
+﻿//===============================================================================================================
+// System  : Sandcastle Tools - Sandcastle Tools Core Class Library
+// File    : ParseMessages.cs
+// Author  : Jason Curl (jcurl@arcor.de)
+// Updated : 04/05/2026
+// Note    : Copyright 2026, SHFB project, All rights reserved
+//
+// Contains a warning entry, raised from the builder.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://GitHub.com/EWSoftware/SHFB.  This
+// notice, the author's name, and all copyright notices must remain intact in all applications, documentation,
+// and source files.
+//
+//    Date     Who  Comments
+// ==============================================================================================================
+// 04/05/2025  JMC  Created the code
+//===============================================================================================================
+
+using System;
+
+namespace Sandcastle.Core.Markdown.Extensions.Inclusion;
+
+/// <summary>
+/// An entry for a warning message.
+/// </summary>
+public readonly struct ParseMessages
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParseMessages"/> struct.
+    /// </summary>
+    /// <param name="code">The warning code.</param>
+    /// <param name="message">The message for the warning.</param>
+    public ParseMessages(string code, string message)
+    {
+        Code = code ?? String.Empty;
+        Message = message ?? String.Empty;
+    }
+
+    public string Code { get; }
+
+    public string Message { get; }
+}

--- a/SHFB/Source/SandcastleCore/Markdown/MarkdownToMamlConverter.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/MarkdownToMamlConverter.cs
@@ -2,8 +2,8 @@
 // System  : Sandcastle Tools - Sandcastle Tools Core Class Library
 // File    : MarkdownToMamlConverter.cs
 // Author  : Eric Woodruff  (Eric@EWoodruff.us)
-// Updated : 12/03/2025
-// Note    : Copyright 2025, Eric Woodruff, All rights reserved
+// Updated : 04/05/2026
+// Note    : Copyright 2025-2026, Eric Woodruff, All rights reserved
 //
 // This file contains a class used to convert Markdown content to MAML format for the build
 //
@@ -15,6 +15,7 @@
 //    Date     Who  Comments
 // ==============================================================================================================
 // 11/25/2025  EFW  Created the code
+// 04/05/2026  JMC  Updated to use the new inclusion extension
 //===============================================================================================================
 
 using System.Collections.Generic;
@@ -24,6 +25,7 @@ using Markdig;
 using Markdig.Parsers;
 
 using Sandcastle.Core.Markdown.Extensions;
+using Sandcastle.Core.Markdown.Extensions.Inclusion;
 using Sandcastle.Core.Markdown.Parsers;
 using Sandcastle.Core.Markdown.Renderers;
 
@@ -95,6 +97,7 @@ public class MarkdownToMamlConverter
             .UseAutoLinks()
             .UseReferralLinks("noopener", "noreferrer")
             .UseEmojiAndSmiley()
+            .Use(new InclusionExtension())
             .UseGenericAttributes();    // This one must be added last
 
         // Register the new extension to post-process HtmlBlock contents
@@ -130,6 +133,7 @@ public class MarkdownToMamlConverter
     /// <returns>The MAML representation of the Markdown content</returns>
     public string ConvertFromFile(string id, string markdownFile)
     {
+        InclusionFiles.PushFile(markdownFile);
         return ConvertFromMarkdown(id, File.ReadAllText(markdownFile));
     }
 

--- a/SHFB/Source/SandcastleCore/Markdown/MarkdownToMamlConverter.cs
+++ b/SHFB/Source/SandcastleCore/Markdown/MarkdownToMamlConverter.cs
@@ -69,6 +69,18 @@ public class MarkdownToMamlConverter
     }
     #endregion
 
+    #region Properties
+    //=====================================================================
+
+    private List<ParseMessages> markdownWarnings = new();
+
+    /// <summary>
+    /// Gets a list of warnings when parsing this node.
+    /// </summary>
+    /// <value>The list of warnings.</value>
+    public IList<ParseMessages> Warnings { get { return markdownWarnings; } }
+    #endregion
+
     #region Methods
     //=====================================================================
 
@@ -133,8 +145,11 @@ public class MarkdownToMamlConverter
     /// <returns>The MAML representation of the Markdown content</returns>
     public string ConvertFromFile(string id, string markdownFile)
     {
+        markdownWarnings.Clear();
         InclusionFiles.PushFile(markdownFile);
-        return ConvertFromMarkdown(id, File.ReadAllText(markdownFile));
+        string maml = ConvertFromMarkdown(id, File.ReadAllText(markdownFile));
+        markdownWarnings.AddRange(InclusionFiles.Warnings);
+        return maml;
     }
 
     /// <summary>


### PR DESCRIPTION
Markdown files with the text `[!INCLUDE [](file.md)]` will be included while parsing the markdown files, and then rendered into the MAML output.

Issue: https://github.com/EWSoftware/SHFB/issues/1173